### PR TITLE
Week05

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module https://github.com/safiweb/gopherguides-intro-to-go
+module github.com/safiweb/gopherguides-intro-to-go
 
 go 1.17

--- a/week03/go.mod
+++ b/week03/go.mod
@@ -1,3 +1,0 @@
-module gopherguides-intro-to-go/week03
-
-go 1.17

--- a/week04/go.mod
+++ b/week04/go.mod
@@ -1,3 +1,0 @@
-module gopherguides-intro-to-go/week04
-
-go 1.17

--- a/week05/clause.go
+++ b/week05/clause.go
@@ -1,0 +1,29 @@
+package week05
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type Clauses map[string]interface{}
+
+func (cls Clauses) String() string {
+	lines := make([]string, 0, len(cls))
+
+	for k, v := range cls {
+		lines = append(lines, fmt.Sprintf("%q = %q", k, v))
+	}
+
+	sort.Strings(lines)
+	return strings.Join(lines, " and ")
+}
+
+func (cls Clauses) Match(m Model) bool {
+	for k, v := range cls {
+		if m[k] != v {
+			return false
+		}
+	}
+	return true
+}

--- a/week05/clause_test.go
+++ b/week05/clause_test.go
@@ -1,0 +1,79 @@
+package week05
+
+import (
+	"testing"
+)
+
+func TestClauses_String(t *testing.T) {
+
+	t.Parallel()
+
+	testcases := []struct {
+		name string
+		cls  Clauses
+		want string
+	}{
+		{
+			name: "no clauses provided",
+			cls:  Clauses{},
+			want: "",
+		},
+		{
+			name: "clauses provided",
+			cls:  Clauses{"animals": "Lion", "sports": "F1"},
+			want: `"animals" = "Lion" and "sports" = "F1"`,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+
+			got := tt.cls.String()
+			if got != tt.want {
+				t.Fatalf("unexpected value, got: %v, exp: %v", got, tt.cls)
+			}
+
+		})
+	}
+}
+
+func TestClauses_Match(t *testing.T) {
+
+	t.Parallel()
+
+	testcases := []struct {
+		name string
+		cls  Clauses
+		m    Model
+		want bool
+	}{
+		{
+			name: "nil data provided",
+			cls:  Clauses{"animals": "Lion", "sports": "F1", "person": "Anthony"},
+			m:    Model{},
+			want: false,
+		},
+		{
+			name: "matching data provided",
+			cls:  Clauses{"animals": "Lion", "sports": "F1", "person": "Anthony"},
+			m:    Model{"sports": "F1", "person": "Anthony", "animals": "Lion"},
+			want: true,
+		},
+		{name: "no matching data provided",
+			cls:  Clauses{"animals": "Lion", "sports": "F1", "person": "Anthony"},
+			m:    Model{"sports": "F1", "person": "Webbs", "animals": "Lion"},
+			want: false,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+
+			got := tt.cls.Match(tt.m)
+			if got != tt.want {
+				t.Fatalf("unexpected value, got: %v, exp: %v", got, tt.want)
+			}
+
+		})
+	}
+}

--- a/week05/errors.go
+++ b/week05/errors.go
@@ -1,0 +1,75 @@
+package week05
+
+import (
+	"errors"
+	"fmt"
+)
+
+type ErrTableNotFound struct {
+	table string
+}
+
+func (e ErrTableNotFound) Error() string {
+	return fmt.Sprintf("table not found %s", e.table)
+}
+
+func (e ErrTableNotFound) TableNotFound() string {
+	return e.table
+}
+
+func (e ErrTableNotFound) Is(err error) bool {
+	_, ok := err.(ErrTableNotFound)
+	return ok
+}
+
+func IsErrTableNotFound(err error) bool {
+	return errors.Is(err, ErrTableNotFound{})
+}
+
+// --- ErrNoRows ---
+
+type ErrNoRows interface {
+	error
+	RowNotFound() (string, Clauses)
+}
+
+var _ ErrNoRows = &errNoRows{}
+
+type errNoRows struct {
+	clauses Clauses
+	table   string
+}
+
+func (e *errNoRows) Error() string {
+	return fmt.Sprintf("[%s] no rows found\nquery: %s", e.table, e.Clauses())
+}
+
+func (e *errNoRows) Clauses() Clauses {
+	if e.clauses == nil {
+		e.clauses = Clauses{}
+	}
+
+	return e.clauses
+}
+
+func (e *errNoRows) RowNotFound() (string, Clauses) {
+	return e.table, e.Clauses()
+}
+
+func (e *errNoRows) Is(err error) bool {
+	_, ok := err.(*errNoRows)
+	return ok
+}
+
+func IsErrNoRows(err error) bool {
+	return errors.Is(err, &errNoRows{})
+}
+
+func AsErrNoRows(err error) (ErrNoRows, bool) {
+	e := &errNoRows{}
+	if errors.As(err, &e) {
+		return e, true
+	}
+
+	return nil, false
+}

--- a/week05/errors_test.go
+++ b/week05/errors_test.go
@@ -1,0 +1,249 @@
+package week05
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestErrors_TableNotFound(t *testing.T) {
+
+	t.Parallel()
+
+	testcases := []struct {
+		name     string
+		errTable ErrTableNotFound
+		want     string
+	}{
+		{
+			name:     "empty err table",
+			errTable: ErrTableNotFound{},
+			want:     "",
+		},
+		{
+			name:     "err table with data",
+			errTable: ErrTableNotFound{table: "users"},
+			want:     "users",
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+
+			got := tt.errTable.TableNotFound()
+
+			if got != tt.want {
+				t.Fatalf("unexpected error: got %v, want %v", got, tt.want)
+			}
+
+		})
+	}
+}
+
+func TestErrors_IsErrTableNotFound(t *testing.T) {
+
+	t.Parallel()
+
+	testcases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "not ErrTableNotFound error",
+			err:  fmt.Errorf("hello"),
+			want: false,
+		},
+		{
+			name: "not not ErrTableNotFound error",
+			err:  &ErrTableNotFound{table: "users"},
+			want: true,
+		},
+		{
+			name: "empty ErrTableNotFound error",
+			err:  &ErrTableNotFound{},
+			want: true,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+
+			got := IsErrTableNotFound(tt.err)
+
+			if got != tt.want {
+				t.Fatalf("unexpected error: got %v, want %v", got, tt.want)
+			}
+
+		})
+	}
+}
+
+func TestErrors_Clauses(t *testing.T) {
+
+	t.Parallel()
+
+	testcases := []struct {
+		name string
+		err  *errNoRows
+		want Clauses
+	}{
+		{
+			name: "empty clauses provided",
+			err:  &errNoRows{nil, "users"},
+			want: nil,
+		},
+		{
+			name: "clauses provided correct expected",
+			err:  &errNoRows{Clauses{"hobby": "golf", "name": "Webbs"}, "users"},
+			want: Clauses{"name": "Webbs", "hobby": "golf"},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.err.Clauses()
+			assertEqualClause(t, got, tt.want)
+
+		})
+	}
+}
+
+func TestErrors_RowNotFound(t *testing.T) {
+
+	t.Parallel()
+
+	testcases := []struct {
+		name    string
+		err     *errNoRows
+		want    string
+		clauses Clauses
+	}{
+		{
+			name:    "empty clauses and table name",
+			err:     &errNoRows{Clauses{}, ""},
+			want:    "",
+			clauses: Clauses{},
+		},
+		{
+			name:    "empty clauses, correct table name provided",
+			err:     &errNoRows{Clauses{}, "users"},
+			want:    "users",
+			clauses: Clauses{},
+		},
+		{
+			name:    "correct clauses, correct table provided",
+			err:     &errNoRows{Clauses{"hobby": "golf", "name": "Webbs"}, "users"},
+			want:    "users",
+			clauses: Clauses{"hobby": "golf", "name": "Webbs"},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			got, c := tt.err.RowNotFound()
+
+			if got != tt.want {
+				t.Fatalf("unexpected error: got %v, want %v", got, tt.want)
+			}
+
+			assertEqualClause(t, c, tt.clauses)
+
+		})
+	}
+
+}
+
+func TestErrors_IsErrNoRows(t *testing.T) {
+
+	t.Parallel()
+
+	testcases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "errNoRows error type, empty clauses",
+			err:  &errNoRows{Clauses{}, "users"},
+			want: true,
+		},
+		{
+			name: "errNoRows error type, correct data",
+			err:  &errNoRows{Clauses{"hobby": "golf", "name": "Webbs"}, "users"},
+			want: true,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+
+			got := IsErrNoRows(tt.err)
+
+			if got != tt.want {
+				t.Fatalf("unexpected error: got %v, want %v", got, tt.want)
+			}
+
+		})
+	}
+
+}
+
+func TestErrors_AsErrNoRows(t *testing.T) {
+
+	t.Parallel()
+
+	testcases := []struct {
+		name    string
+		err     error
+		errRows ErrNoRows
+		want    bool
+	}{
+		{
+			name:    "not errNoRows error type",
+			err:     fmt.Errorf("hello"),
+			errRows: &errNoRows{},
+			want:    false,
+		},
+		{
+			name:    "errNoRows error type, empty query clauses",
+			err:     &errNoRows{Clauses{}, "users"},
+			errRows: &errNoRows{Clauses{}, "users"},
+			want:    true,
+		},
+		{
+			name:    "errNoRows error type, wrong query clauses",
+			err:     &errNoRows{Clauses{"hobby": "golf", "name": "Webbs"}, "users"},
+			errRows: &errNoRows{Clauses{"hobby": "golf", "name": "Webbs"}, "users"},
+			want:    true,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+
+			got, gotWant := AsErrNoRows(tt.err)
+
+			if got != nil {
+				if got.Error() != tt.errRows.Error() {
+					t.Fatalf("unexpected error: got %v, want %v", got.Error(), tt.errRows.Error())
+				}
+			}
+
+			if gotWant != tt.want {
+				t.Fatalf("unexpected error: got %v, want %v", gotWant, tt.want)
+			}
+
+		})
+	}
+
+}
+
+func assertEqualClause(t testing.TB, got Clauses, want Clauses) {
+	t.Helper()
+
+	for k, v := range want {
+		if got[k] != v {
+			t.Fatalf("unexpected error: got %v, want %v", got, want)
+		}
+	}
+}

--- a/week05/store.go
+++ b/week05/store.go
@@ -1,0 +1,72 @@
+package week05
+
+type Model map[string]interface{}
+
+type Models []Model
+
+type data map[string]Models
+
+type Store struct {
+	data data
+}
+
+func (s *Store) db() data {
+	if s.data == nil {
+		s.data = data{}
+	}
+
+	return s.data
+}
+
+func (s *Store) All(tn string) (Models, error) {
+	db := s.db()
+
+	mods, ok := db[tn]
+	if !ok {
+		return nil, &ErrTableNotFound{table: tn}
+	}
+
+	return mods, nil
+}
+
+func (s Store) Len(tn string) (int, error) {
+	rows, err := s.All(tn)
+	if err != nil {
+		return 0, err
+	}
+
+	return len(rows), nil
+}
+
+func (s *Store) Insert(tn string, mod ...Model) {
+	db := s.db()
+	db[tn] = append(db[tn], mod...)
+}
+
+func (s *Store) Select(tn string, query Clauses) (Models, error) {
+	rows, err := s.All(tn)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(query) == 0 {
+		return rows, nil
+	}
+
+	res := make(Models, 0, len(rows))
+
+	for _, m := range rows {
+		if query.Match(m) {
+			res = append(res, m)
+		}
+	}
+
+	if len(res) == 0 {
+		return nil, &errNoRows{
+			clauses: query,
+			table:   tn,
+		}
+	}
+
+	return res, nil
+}

--- a/week05/store_test.go
+++ b/week05/store_test.go
@@ -1,0 +1,228 @@
+package week05
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestStore_All(t *testing.T) {
+
+	t.Parallel()
+
+	testcases := []struct {
+		name  string
+		table string
+		store *Store
+		err   error
+	}{
+		{
+			name:  "store with no data",
+			table: "users",
+			store: &Store{},
+			err:   ErrTableNotFound{},
+		},
+		{
+			name:  "store with data",
+			table: "users",
+			store: &Store{data: data{}},
+			err:   ErrTableNotFound{},
+		},
+		{
+			name:  "store with data, users",
+			table: "users",
+			store: &Store{data: data{"users": Models{}}},
+			err:   nil,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+
+			_, err := tt.store.All(tt.table)
+
+			if tt.err != nil {
+				ok := errors.Is(err, tt.err)
+				if !ok {
+					t.Fatalf("expected error %v, got %v", tt.err, err)
+				}
+				return
+			}
+
+			assertError(t, err)
+		})
+	}
+
+}
+
+func TestStore_Len(t *testing.T) {
+
+	t.Parallel()
+
+	john := Model{
+		"name":   "John",
+		"gender": "M",
+	}
+
+	tom := Model{
+		"name":   "Tom",
+		"gender": "M",
+	}
+
+	myStore := &Store{}
+	myStore.Insert("users", john, tom)
+
+	testcases := []struct {
+		name  string
+		table string
+		err   error
+		want  int
+	}{
+		{
+			name:  "table exists",
+			table: "users",
+			err:   nil,
+			want:  2,
+		},
+		{
+			name:  "table doesn't exist",
+			table: "people",
+			err:   &ErrTableNotFound{table: "people"},
+			want:  0,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+
+			got, err := myStore.Len(tt.table)
+
+			if tt.err != nil {
+				if tt.err.Error() != err.Error() {
+					t.Fatalf("unexpected error: got %v, want %v", err, tt.err)
+				}
+				return
+			}
+
+			assertError(t, err)
+
+			if got != tt.want {
+				t.Fatalf("unexpected error: got %v, want %v", got, tt.want)
+			}
+
+		})
+	}
+
+}
+
+func TestStore_Insert(t *testing.T) {
+
+	t.Parallel()
+
+	want := 2
+	myStore := &Store{}
+	myStore.Insert("users", Model{"name": "Jane", "gender": "F"}, Model{"name": "Anthony", "gender": "M"})
+
+	got, err := myStore.Len("users")
+	assertError(t, err)
+
+	if got != want {
+		t.Fatalf("unexpected error: got %v, want %v", got, want)
+	}
+
+}
+
+func TestStore_Select(t *testing.T) {
+
+	t.Parallel()
+
+	john := Model{
+		"name":   "John",
+		"gender": "M",
+	}
+
+	tom := Model{
+		"name":   "Tom",
+		"gender": "M",
+	}
+
+	myStore := &Store{}
+	myStore.Insert("users", john, tom)
+	myStore.Insert("items")
+
+	testcases := []struct {
+		name  string
+		table string
+		query Clauses
+		err   error
+		want  Models
+	}{
+		{
+			name:  "table doesn't exist",
+			table: "orders",
+			query: Clauses{},
+			err:   ErrTableNotFound{table: "orders"},
+			want:  Models{},
+		},
+		{
+			name:  "row doesn't exist",
+			table: "users",
+			query: Clauses{"name": "Jane", "gender": "F"},
+			err:   &errNoRows{table: "users"},
+			want:  Models{},
+		},
+		{
+			name:  "correct table, row requested",
+			table: "users",
+			query: Clauses{"name": "Tom", "gender": "M"},
+			err:   nil,
+			want:  Models{Model{"name": "Tom", "gender": "M"}},
+		},
+		{
+			name:  "no data",
+			table: "users",
+			query: Clauses{},
+			err:   nil,
+			want:  Models{},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+
+			got, err := myStore.Select(tt.table, tt.query)
+
+			if tt.err != nil {
+				ok := errors.Is(err, tt.err)
+				if !ok {
+					t.Fatalf("expected error %v, got %v", tt.err, err)
+				}
+				return
+			}
+
+			assertError(t, err)
+
+			for i, model := range tt.want {
+				assertEqualModel(t, got[i], model)
+			}
+
+		})
+	}
+
+}
+
+func assertError(t testing.TB, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertEqualModel(t testing.TB, got Model, want Model) {
+	t.Helper()
+	for k, v := range want {
+		if got[k] != v {
+			t.Fatalf("unexpected error: got %v, want %v", got, want)
+		}
+	}
+}


### PR DESCRIPTION
# Adding unit tests for the specified set of code

This PR adds unit tests for the set of code in clause.go, store.go and errors.go files. The tests are table-driven tests using subtests.  

For clause.go, the unit tests are in clause_test.go. Here we have two unit test functions:

_**TestClauses_String**_ which calls the _Strings()_ method and runs the sub test cases, comparing what we got with what we wanted.

```
E:\Projects\Go\src\gopherguides-intro-to-go\week05>go test -v -run TestClauses_String ./...
=== RUN   TestClauses_String
=== PAUSE TestClauses_String
=== CONT  TestClauses_String
=== RUN   TestClauses_String/no_clauses_provided
=== RUN   TestClauses_String/clauses_provided
--- PASS: TestClauses_String (0.00s)
    --- PASS: TestClauses_String/no_clauses_provided (0.00s)
    --- PASS: TestClauses_String/clauses_provided (0.00s)
PASS
ok      github.com/safiweb/gopherguides-intro-to-go/week05
```

**_TestClauses_Match_** which calls the _Match()_ method and runs the sub test cases, comparing what we got with what we wanted.

```
E:\Projects\Go\src\gopherguides-intro-to-go\week05>go test -v -run TestClauses_Match ./...
=== RUN   TestClauses_Match
=== PAUSE TestClauses_Match
=== CONT  TestClauses_Match
=== RUN   TestClauses_Match/nil_data_provided
=== RUN   TestClauses_Match/matching_data_provided
=== RUN   TestClauses_Match/no_matching_data_provided
--- PASS: TestClauses_Match (0.00s)
    --- PASS: TestClauses_Match/nil_data_provided (0.00s)
    --- PASS: TestClauses_Match/matching_data_provided (0.00s)
    --- PASS: TestClauses_Match/no_matching_data_provided (0.00s)
PASS
ok      github.com/safiweb/gopherguides-intro-to-go/week05      0.228s
```

For store.go, the unit tests are in store_test.go. Here we have these four unit test functions:

**_TestStore_All_** which calls the _All_ method and runs the sub test cases, comparing what we got with what we wanted. It asserts error and the _Models_ returned via _assertError_ and _assertEqualModels_ helper functions.

```
E:\Projects\Go\src\gopherguides-intro-to-go\week05>go test -v -run TestStore_All ./...
=== RUN   TestStore_All
=== PAUSE TestStore_All
=== CONT  TestStore_All
=== RUN   TestStore_All/store_with_no_data
=== RUN   TestStore_All/store_with_data
=== RUN   TestStore_All/store_with_data,_users
--- PASS: TestStore_All (0.00s)
    --- PASS: TestStore_All/store_with_no_data (0.00s)
    --- PASS: TestStore_All/store_with_data (0.00s)
    --- PASS: TestStore_All/store_with_data,_users (0.00s)
PASS
ok      github.com/safiweb/gopherguides-intro-to-go/week05      0.205s
```

**_TestStore_Len_** which calls the _Len_ method and runs the sub test cases, comparing what we got with what we wanted. It asserts the error and the wanted value. The error is asserted via _assertError_ helper function.

```
E:\Projects\Go\src\gopherguides-intro-to-go\week05>go test -v -run TestStore_Len ./...
=== RUN   TestStore_Len
=== PAUSE TestStore_Len
=== CONT  TestStore_Len
=== RUN   TestStore_Len/table_exists
=== RUN   TestStore_Len/table_doesn't_exist
--- PASS: TestStore_Len (0.00s)
    --- PASS: TestStore_Len/table_exists (0.00s)
    --- PASS: TestStore_Len/table_doesn't_exist (0.00s)
PASS
ok      github.com/safiweb/gopherguides-intro-to-go/week05      0.131s
```

**_TestStore_Insert_** which calls the _Insert_ method and runs the sub test cases, checking if the data was inserted into the table.

```
E:\Projects\Go\src\gopherguides-intro-to-go\week05>go test -v -run TestStore_Insert ./...
=== RUN   TestStore_Insert
=== PAUSE TestStore_Insert
=== CONT  TestStore_Insert
--- PASS: TestStore_Insert (0.00s)
PASS
ok      github.com/safiweb/gopherguides-intro-to-go/week05      0.266s
```

**_TestStore_Select_** which calls the _Select_ method and runs the sub test cases, comparing what we got with what we wanted. Checking if the provided query clauses returned correct data and table. It asserts error and the _Models_ returned via _assertError_ and _assertEqualModels_ helper functions.

```
E:\Projects\Go\src\gopherguides-intro-to-go\week05>go test -v -run TestStore_Select ./...
=== RUN   TestStore_Select
=== PAUSE TestStore_Select
=== CONT  TestStore_Select
=== RUN   TestStore_Select/table_doesn't_exist
=== RUN   TestStore_Select/row_doesn't_exist
=== RUN   TestStore_Select/correct_table,_row_requested
=== RUN   TestStore_Select/no_data
--- PASS: TestStore_Select (0.00s)
    --- PASS: TestStore_Select/table_doesn't_exist (0.00s)
    --- PASS: TestStore_Select/row_doesn't_exist (0.00s)
    --- PASS: TestStore_Select/correct_table,_row_requested (0.00s)
    --- PASS: TestStore_Select/no_data (0.00s)
PASS
ok      github.com/safiweb/gopherguides-intro-to-go/week05      0.142s
```

For errors.go, the unit tests are in errors_test.go. Here we have these six-unit test functions:

**_TestErrors_TableNotFound_**  which calls the _TableNotFound_ function and runs the sub test cases, comparing what we got with what we wanted.

```

E:\Projects\Go\src\gopherguides-intro-to-go\week05>go test -v -run TestErrors_TableNotFound ./...
=== RUN   TestErrors_TableNotFound
=== PAUSE TestErrors_TableNotFound
=== CONT  TestErrors_TableNotFound
=== RUN   TestErrors_TableNotFound/empty_err_table
=== RUN   TestErrors_TableNotFound/err_table_with_data
--- PASS: TestErrors_TableNotFound (0.00s)
    --- PASS: TestErrors_TableNotFound/empty_err_table (0.00s)
    --- PASS: TestErrors_TableNotFound/err_table_with_data (0.00s)
PASS
ok      github.com/safiweb/gopherguides-intro-to-go/week05      0.161s
```

**_TestErrors_IsErrTableNotFound_** which calls the _IsErrTableNotFound_ function and runs the sub test cases, comparing what we got with what we wanted.

```
E:\Projects\Go\src\gopherguides-intro-to-go\week05>go test -v -run TestErrors_IsErrTableNotFound ./...
=== RUN   TestErrors_IsErrTableNotFound
=== PAUSE TestErrors_IsErrTableNotFound
=== CONT  TestErrors_IsErrTableNotFound
=== RUN   TestErrors_IsErrTableNotFound/not_ErrTableNotFound_error
=== RUN   TestErrors_IsErrTableNotFound/not_not_ErrTableNotFound_error
=== RUN   TestErrors_IsErrTableNotFound/empty_ErrTableNotFound_error
--- PASS: TestErrors_IsErrTableNotFound (0.00s)
    --- PASS: TestErrors_IsErrTableNotFound/not_ErrTableNotFound_error (0.00s)
    --- PASS: TestErrors_IsErrTableNotFound/not_not_ErrTableNotFound_error (0.00s)
    --- PASS: TestErrors_IsErrTableNotFound/empty_ErrTableNotFound_error (0.00s)
PASS
ok      github.com/safiweb/gopherguides-intro-to-go/week05      0.168s
```

**_TestErrors_Clauses_** which calls the _Clauses_ method and runs the sub test cases, comparing what we got with what we wanted.

```
E:\Projects\Go\src\gopherguides-intro-to-go\week05>go test -v -run TestErrors_Clauses ./...
=== RUN   TestErrors_Clauses
=== PAUSE TestErrors_Clauses
=== CONT  TestErrors_Clauses
=== RUN   TestErrors_Clauses/empty_clauses_provided
=== RUN   TestErrors_Clauses/clauses_provided_correct_expected
--- PASS: TestErrors_Clauses (0.00s)
    --- PASS: TestErrors_Clauses/empty_clauses_provided (0.00s)
    --- PASS: TestErrors_Clauses/clauses_provided_correct_expected (0.00s)
PASS
ok      github.com/safiweb/gopherguides-intro-to-go/week05      0.147s
```

**_TestErrors_RowNotFound_** which calls the _RowNotFound_ method and runs the sub test cases, comparing what we got with what we wanted.

```

E:\Projects\Go\src\gopherguides-intro-to-go\week05>go test -v -run TestErrors_RowNotFound ./...
=== RUN   TestErrors_RowNotFound
=== PAUSE TestErrors_RowNotFound
=== CONT  TestErrors_RowNotFound
=== RUN   TestErrors_RowNotFound/empty_clauses_and_table_name
=== RUN   TestErrors_RowNotFound/empty_clauses,_correct_table_name_provided
=== RUN   TestErrors_RowNotFound/correct_clauses,_correct_table_provided
--- PASS: TestErrors_RowNotFound (0.00s)
    --- PASS: TestErrors_RowNotFound/empty_clauses_and_table_name (0.00s)
    --- PASS: TestErrors_RowNotFound/empty_clauses,_correct_table_name_provided (0.00s)
    --- PASS: TestErrors_RowNotFound/correct_clauses,_correct_table_provided (0.00s)
PASS
ok      github.com/safiweb/gopherguides-intro-to-go/week05      0.148s
```

**_TestErrors_IsErrNoRows_** which calls the _IsErrNoRows_ function and runs the sub test cases, comparing what we got with what we wanted. 

```
E:\Projects\Go\src\gopherguides-intro-to-go\week05>go test -v -run TestErrors_IsErrNoRows ./...
=== RUN   TestErrors_IsErrNoRows
=== PAUSE TestErrors_IsErrNoRows
=== CONT  TestErrors_IsErrNoRows
=== RUN   TestErrors_IsErrNoRows/errNoRows_error_type,_empty_clauses
=== RUN   TestErrors_IsErrNoRows/errNoRows_error_type,_correct_data
--- PASS: TestErrors_IsErrNoRows (0.00s)
    --- PASS: TestErrors_IsErrNoRows/errNoRows_error_type,_empty_clauses (0.00s)
    --- PASS: TestErrors_IsErrNoRows/errNoRows_error_type,_correct_data (0.00s)
PASS
ok      github.com/safiweb/gopherguides-intro-to-go/week05      0.142s
```

**_TestErrors_AsErrNoRows_** which calls the _AsErrNoRows_ method and runs the sub test cases, comparing what we got with what we wanted.

```
E:\Projects\Go\src\gopherguides-intro-to-go\week05>go test -v -run TestErrors_AsErrNoRows ./...
=== RUN   TestErrors_AsErrNoRows
=== PAUSE TestErrors_AsErrNoRows
=== CONT  TestErrors_AsErrNoRows
=== RUN   TestErrors_AsErrNoRows/not_errNoRows_error_type
=== RUN   TestErrors_AsErrNoRows/errNoRows_error_type,_empty_query_clauses
=== RUN   TestErrors_AsErrNoRows/errNoRows_error_type,_wrong_query_clauses
--- PASS: TestErrors_AsErrNoRows (0.00s)
    --- PASS: TestErrors_AsErrNoRows/not_errNoRows_error_type (0.00s)
    --- PASS: TestErrors_AsErrNoRows/errNoRows_error_type,_empty_query_clauses (0.00s)
    --- PASS: TestErrors_AsErrNoRows/errNoRows_error_type,_wrong_query_clauses (0.00s)
PASS
ok      github.com/safiweb/gopherguides-intro-to-go/week05      0.156s
```

The tests achieved 100% coverage as seen below:

```
E:\Projects\Go\src\gopherguides-intro-to-go\week05>go tool cover -func coverage.out
github.com/safiweb/gopherguides-intro-to-go/week05/clause.go:11:        String                  100.0%
github.com/safiweb/gopherguides-intro-to-go/week05/clause.go:22:        Match                   100.0%
github.com/safiweb/gopherguides-intro-to-go/week05/errors.go:12:        Error                   100.0%
github.com/safiweb/gopherguides-intro-to-go/week05/errors.go:16:        TableNotFound           100.0%
github.com/safiweb/gopherguides-intro-to-go/week05/errors.go:20:        Is                      100.0%
github.com/safiweb/gopherguides-intro-to-go/week05/errors.go:25:        IsErrTableNotFound      100.0%
github.com/safiweb/gopherguides-intro-to-go/week05/errors.go:43:        Error                   100.0%
github.com/safiweb/gopherguides-intro-to-go/week05/errors.go:47:        Clauses                 100.0%
github.com/safiweb/gopherguides-intro-to-go/week05/errors.go:55:        RowNotFound             100.0%
github.com/safiweb/gopherguides-intro-to-go/week05/errors.go:59:        Is                      100.0%
github.com/safiweb/gopherguides-intro-to-go/week05/errors.go:64:        IsErrNoRows             100.0%
github.com/safiweb/gopherguides-intro-to-go/week05/errors.go:68:        AsErrNoRows             100.0%
github.com/safiweb/gopherguides-intro-to-go/week05/store.go:13:         db                      100.0%
github.com/safiweb/gopherguides-intro-to-go/week05/store.go:21:         All                     100.0%
github.com/safiweb/gopherguides-intro-to-go/week05/store.go:32:         Len                     100.0%
github.com/safiweb/gopherguides-intro-to-go/week05/store.go:41:         Insert                  100.0%
github.com/safiweb/gopherguides-intro-to-go/week05/store.go:46:         Select                  100.0%
total:                                                                  (statements)            100.0%
```

## Changes Summary
Added clause.go, store.go, errors.go that have specified assignment code
Added clause_test.go, store_test.go and errors_test.go that have unit test functions
Miscellaneous - formatting code

## Difficulties
- Calling  t.Parallel() in sub tests brought different test results and also made test coverage not achieavable. It's similar as explained here [https://gist.github.com/posener/92a55c4cd441fc5e5e85f27bca008721](https://gist.github.com/posener/92a55c4cd441fc5e5e85f27bca008721). I had to revert to the conventional way i.e calling t.Parallel() at the very top of the test function.

- A method or function returns more than one result - testing for only one result made the test coverage to be minimal. Had to test for all results.

## Surprises

Table-driven tests using subtests are more cleaner and enjoyable to write. 
