### PR TITLE
Week06

### DIFF
--- a/week06/completed_product.go
+++ b/week06/completed_product.go
@@ -1,0 +1,20 @@
+package week06
+
+// CompletedProduct represents a completed product
+type CompletedProduct struct {
+	Product  Product  // Built Product
+	Employee Employee // Employee who built the product
+}
+
+// IsValid returns true if the product has been built.
+func (cp CompletedProduct) IsValid() error {
+	if err := cp.Employee.IsValid(); err != nil {
+		return err
+	}
+
+	if err := cp.Product.IsBuilt(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/week06/completed_product_test.go
+++ b/week06/completed_product_test.go
@@ -10,19 +10,17 @@ func TestCompletedProduct_IsValid(t *testing.T) {
 	t.Parallel()
 
 	//Build a product of 1 Quantity for 1 Employee
-	myProduct := Product{Quantity: 1}
-	myProduct.Build(1)
+	prod := Product{Quantity: 1}
+	prod.Build(1)
 
-	//Build a product of 0 Quantity for 1 Employee
-	myProductNoQuantity := Product{}
-	myProductNoQuantity.Build(1)
+	//Employee
+	e := Employee(1)
 
 	//Different Complete Products for different scenarios
-	emptyCompleteProduct := CompletedProduct{}
-	completeProductNoEmployee := CompletedProduct{Product: myProduct, Employee: Employee(0)}
-	completeProductNotBuild := CompletedProduct{Product: Product{Quantity: 1}, Employee: Employee(1)}
-	completeProductNoQuantity := CompletedProduct{Product: myProductNoQuantity, Employee: Employee(1)}
-	completeProductFull := CompletedProduct{Product: myProduct, Employee: Employee(1)}
+	empty := CompletedProduct{}
+	noEmployee := CompletedProduct{Product: prod, Employee: Employee(0)}
+	notBuild := CompletedProduct{Product: Product{Quantity: 1}, Employee: e}
+	good := CompletedProduct{Product: prod, Employee: e}
 
 	testcases := []struct {
 		name string
@@ -31,27 +29,22 @@ func TestCompletedProduct_IsValid(t *testing.T) {
 	}{
 		{
 			name: "empty complete product",
-			cp:   emptyCompleteProduct,
+			cp:   empty,
 			err:  fmt.Errorf("invalid employee number: 0"),
 		},
 		{
 			name: "complete product no employee",
-			cp:   completeProductNoEmployee,
+			cp:   noEmployee,
 			err:  fmt.Errorf("invalid employee number: 0"),
 		},
 		{
 			name: "complete product no buildby",
-			cp:   completeProductNotBuild,
+			cp:   notBuild,
 			err:  fmt.Errorf("product is not built: {1 0}"),
 		},
 		{
-			name: "complete product no quantity",
-			cp:   completeProductNoQuantity,
-			err:  fmt.Errorf("quantity must be greater than 0, got 0"),
-		},
-		{
 			name: "full complete product",
-			cp:   completeProductFull,
+			cp:   good,
 			err:  nil,
 		},
 	}

--- a/week06/completed_product_test.go
+++ b/week06/completed_product_test.go
@@ -1,0 +1,71 @@
+package week06
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestCompletedProduct_IsValid(t *testing.T) {
+
+	t.Parallel()
+
+	//Build a product of 1 Quantity for 1 Employee
+	myProduct := Product{Quantity: 1}
+	myProduct.Build(1)
+
+	//Build a product of 0 Quantity for 1 Employee
+	myProductNoQuantity := Product{}
+	myProductNoQuantity.Build(1)
+
+	//Different Complete Products for different scenarios
+	emptyCompleteProduct := CompletedProduct{}
+	completeProductNoEmployee := CompletedProduct{Product: myProduct, Employee: Employee(0)}
+	completeProductNotBuild := CompletedProduct{Product: Product{Quantity: 1}, Employee: Employee(1)}
+	completeProductNoQuantity := CompletedProduct{Product: myProductNoQuantity, Employee: Employee(1)}
+	completeProductFull := CompletedProduct{Product: myProduct, Employee: Employee(1)}
+
+	testcases := []struct {
+		name string
+		cp   CompletedProduct
+		err  error
+	}{
+		{
+			name: "empty complete product",
+			cp:   emptyCompleteProduct,
+			err:  fmt.Errorf("invalid employee number: 0"),
+		},
+		{
+			name: "complete product no employee",
+			cp:   completeProductNoEmployee,
+			err:  fmt.Errorf("invalid employee number: 0"),
+		},
+		{
+			name: "complete product no buildby",
+			cp:   completeProductNotBuild,
+			err:  fmt.Errorf("product is not built: {1 0}"),
+		},
+		{
+			name: "complete product no quantity",
+			cp:   completeProductNoQuantity,
+			err:  fmt.Errorf("quantity must be greater than 0, got 0"),
+		},
+		{
+			name: "full complete product",
+			cp:   completeProductFull,
+			err:  nil,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cp.IsValid()
+			if got != nil {
+				if got.Error() != tt.err.Error() {
+					t.Fatalf("expected %v, got %v", tt.err, got)
+					return
+				}
+			}
+		})
+	}
+
+}

--- a/week06/employee.go
+++ b/week06/employee.go
@@ -1,0 +1,57 @@
+package week06
+
+// Employee is a worker.
+type Employee int
+
+// IsValid returns an error if the employee is not valid.
+// A valid employee is greater than zero.
+//	valid: Employee(1)
+//	valid: Employee(2)
+//	invalid: Employee(0)
+//	invalid: Employee(-1)
+func (e Employee) IsValid() error {
+	if e > 0 {
+		return nil
+	}
+
+	return ErrInvalidEmployee(e)
+}
+
+// worker listens for work from the manager
+// and tries to complete it.
+func (e Employee) work(m *Manager) {
+
+	// Use an infinite loop so we can listen for the next
+	// message coming down a channel.
+	// Without an infinite loop, the select statement
+	// would process the first channel with a message
+	// and then exit.
+	for {
+
+		// listen for messages on different channels
+		select {
+		case <-m.Done(): // listen for the manager to signal that it is done
+			return
+		case p, ok := <-m.Jobs(): // listen for a new job
+
+			// check if the channel is closed or not
+			if !ok {
+				continue
+			}
+
+			// try to build the product
+			err := p.Build(e)
+
+			if err != nil {
+				// if there is an error, send it to the manager
+				m.Errors() <- err
+				continue
+			}
+
+			// if there is no error, send the product back to the manager
+			m.Complete(e, p)
+
+		}
+	}
+
+}

--- a/week06/employee_test.go
+++ b/week06/employee_test.go
@@ -1,0 +1,35 @@
+package week06
+
+import "testing"
+
+func TestEmployee_IsValid(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name     string
+		employee Employee
+		err      error
+	}{
+		{
+			name:     "invalid employee",
+			employee: Employee(-1),
+			err:      ErrInvalidEmployee(Employee(-1)),
+		},
+		{
+			name:     "valid employee",
+			employee: Employee(1),
+			err:      nil,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.employee.IsValid()
+			if got != nil {
+				if got.Error() != tt.err.Error() {
+					t.Fatalf("expected %v, got %v", tt.err, got)
+				}
+			}
+		})
+	}
+}

--- a/week06/employee_test.go
+++ b/week06/employee_test.go
@@ -37,29 +37,6 @@ func TestEmployee_IsValid(t *testing.T) {
 func TestEmployee_work(t *testing.T) {
 	t.Parallel()
 
-	/*manager := NewManager()
-	defer manager.Stop()
-
-	e := Employee(1)
-	p := Product{Quantity: 1}
-
-	go e.work(manager)
-
-	err := manager.Assign(&p)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	select {
-	case err := <-manager.Errors():
-		t.Fatal(err)
-		return
-	case cp := <-manager.Completed():
-		if check := cp.IsValid(); check != nil {
-			t.Fatal(cp)
-		}
-	}*/
-
 	testcases := []struct {
 		name     string
 		employee Employee

--- a/week06/employee_test.go
+++ b/week06/employee_test.go
@@ -33,3 +33,77 @@ func TestEmployee_IsValid(t *testing.T) {
 		})
 	}
 }
+
+func TestEmployee_work(t *testing.T) {
+	t.Parallel()
+
+	/*manager := NewManager()
+	defer manager.Stop()
+
+	e := Employee(1)
+	p := Product{Quantity: 1}
+
+	go e.work(manager)
+
+	err := manager.Assign(&p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case err := <-manager.Errors():
+		t.Fatal(err)
+		return
+	case cp := <-manager.Completed():
+		if check := cp.IsValid(); check != nil {
+			t.Fatal(cp)
+		}
+	}*/
+
+	testcases := []struct {
+		name     string
+		employee Employee
+		err      error
+	}{
+		{
+			name:     "bad employee",
+			employee: Employee(0),
+			err:      ErrInvalidEmployee(0),
+		},
+		{
+			name:     "good employee",
+			employee: Employee(1),
+			err:      nil,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+
+			manager := NewManager()
+			defer manager.Stop()
+
+			prod := Product{Quantity: 1}
+
+			go tt.employee.work(manager)
+
+			err := manager.Assign(&prod)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			select {
+			case err := <-manager.Errors():
+				if err.Error() != tt.err.Error() {
+					t.Fatalf("expected %v, got %v", tt.err, err)
+				}
+				return
+			case cp := <-manager.Completed():
+				if check := cp.IsValid(); check != nil {
+					t.Fatalf("expected %v, got %v", tt.err, cp)
+				}
+			}
+
+		})
+	}
+}

--- a/week06/errors.go
+++ b/week06/errors.go
@@ -1,0 +1,45 @@
+package week06
+
+import "fmt"
+
+// ErrInvalidQuantity is returned when the product quantity is invalid.
+type ErrInvalidQuantity int
+
+func (e ErrInvalidQuantity) Error() string {
+	return fmt.Sprintf("quantity must be greater than 0, got %d", e)
+}
+
+// ---
+
+// ErrProductNotBuilt is returned when the product is not built.
+type ErrProductNotBuilt string
+
+func (e ErrProductNotBuilt) Error() string {
+	return string(e)
+}
+
+// ---
+
+// ErrInvalidEmployee is returned when the employee number is invalid.
+type ErrInvalidEmployee int
+
+func (e ErrInvalidEmployee) Error() string {
+	return fmt.Sprintf("invalid employee number: %d", e)
+}
+
+// ---
+
+// ErrInvalidEmployeeCount is returned when the employee count is invalid.
+type ErrInvalidEmployeeCount int
+
+func (e ErrInvalidEmployeeCount) Error() string {
+	return fmt.Sprintf("invalid employee count: %d", e)
+}
+
+// ---
+
+type ErrManagerStopped struct{}
+
+func (ErrManagerStopped) Error() string {
+	return "manager is stopped"
+}

--- a/week06/manager.go
+++ b/week06/manager.go
@@ -1,0 +1,145 @@
+package week06
+
+// Manager is responsible for receiving product orders
+// and assigning them to employees. Manager is also responsible
+// for receiving completed products, and listening for errors,
+// from employees. Manager takes products that have been built
+// by employees and returns them to the customer as a CompletedProduct.
+type Manager struct {
+	// non-exported fields (PRIVATE)
+	// !YOU MAY NOT ACCESS THESE FIELDS IN YOUR TESTS!
+	completed chan CompletedProduct
+	errs      chan error
+	jobs      chan *Product
+	quit      chan struct{}
+	stopped   bool
+}
+
+// NewManager will create a new Manager.
+// This function should ALWAYS be used to
+// create a new Manager.
+func NewManager() *Manager {
+	return &Manager{
+		completed: make(chan CompletedProduct),
+		errs:      make(chan error),
+		jobs:      make(chan *Product),
+		quit:      make(chan struct{}),
+	}
+}
+
+// Start will create new employees for the given count,
+// and start listening for jobs and errors.
+// Managers should be stopped using the Stop method
+// when they are no longer needed.
+func (m *Manager) Start(count int) error {
+
+	if count <= 0 {
+		return ErrInvalidEmployeeCount(count)
+	}
+
+	for i := 0; i < count; i++ {
+
+		e := Employee(i + 1)
+		go e.work(m)
+	}
+
+	return nil
+}
+
+// Assign will assign the given products to employees
+// as employeess become available. An invalid product
+// will return an error.
+func (m *Manager) Assign(products ...*Product) error {
+	if m.stopped {
+		return ErrManagerStopped{}
+	}
+
+	// loop through each product and assign it to an employee
+	for _, p := range products {
+		// validate product
+		if err := p.IsValid(); err != nil {
+			return err
+		}
+
+		// assign product to employee
+		// this will block until an employee becomes available
+		m.Jobs() <- p
+	}
+
+	return nil
+}
+
+// Complete will wrap the employee and the product into
+// a CompletedProduct. The will be passed down the Completed()
+// channel as soon as a listener is available to receive it.
+// Complete will error if the employee is invalid or
+// if the product is not built.
+func (m *Manager) Complete(e Employee, p *Product) error {
+	// validate employee
+	if err := e.IsValid(); err != nil {
+		return err
+	}
+
+	// validate product is built
+	if err := p.IsBuilt(); err != nil {
+		return err
+	}
+
+	cp := CompletedProduct{
+		Employee: e,
+		Product:  *p, // deference pointer to value type ype t
+	}
+
+	// Send completed product to Completed() channel
+	// for a listener to receive it.
+	// This will block until a listener is available.
+	m.completedCh() <- cp
+
+	return nil
+}
+
+// completedCh returns the channel for CompletedProducts
+func (m *Manager) completedCh() chan CompletedProduct {
+	return m.completed
+}
+
+// Completed will return a channel that can be listened to
+// for CompletedProducts.
+// This is a read-only channel.
+func (m *Manager) Completed() <-chan CompletedProduct {
+	return m.completedCh()
+}
+
+// Done will return a channel that will be closed
+// when the manager has stopped.
+// Employees should listen to this channel to know
+// when to stop listening for jobs.
+func (m *Manager) Done() <-chan struct{} {
+	return m.quit
+}
+
+// Jobs will return a channel that can be listened to
+// for new products to be built.
+func (m *Manager) Jobs() chan *Product {
+	return m.jobs
+}
+
+// Errors will return a channel that can be listened to
+// and can be used to receive errors from employees.
+func (m *Manager) Errors() chan error {
+	return m.errs
+}
+
+// Stop will stop the manager and clean up all resources.
+func (m *Manager) Stop() {
+	if m.stopped {
+		return
+	}
+
+	m.stopped = true
+
+	// close all channels
+	close(m.quit)
+	close(m.jobs)
+	close(m.errs)
+}

--- a/week06/manager.go
+++ b/week06/manager.go
@@ -139,6 +139,7 @@ func (m *Manager) Stop() {
 	m.stopped = true
 
 	// close all channels
+	close(m.completed)
 	close(m.quit)
 	close(m.jobs)
 	close(m.errs)

--- a/week06/manager_test.go
+++ b/week06/manager_test.go
@@ -101,6 +101,7 @@ func TestManager_Assign(t *testing.T) {
 					t.Fatalf("expected %v, got %v", tt.err, err)
 				}
 			case <-manager.Jobs():
+				manager.Stop()
 				return
 			}
 		})

--- a/week06/manager_test.go
+++ b/week06/manager_test.go
@@ -104,6 +104,8 @@ func TestManager_Assign(t *testing.T) {
 				manager.Stop()
 				return
 			}
+
+			manager.Stop()
 		})
 	}
 }

--- a/week06/manager_test.go
+++ b/week06/manager_test.go
@@ -83,11 +83,6 @@ func TestManager_Assign(t *testing.T) {
 			manager := NewManager()
 			defer manager.Stop()
 
-			err := manager.Start(1)
-			if err != nil {
-				t.Fatal(err)
-			}
-
 			go func() {
 				got := manager.Assign(tt.products)
 				if got != nil {
@@ -100,12 +95,14 @@ func TestManager_Assign(t *testing.T) {
 				if err.Error() != tt.err.Error() {
 					t.Fatalf("expected %v, got %v", tt.err, err)
 				}
-			case <-manager.Jobs():
-				manager.Stop()
 				return
+			case p := <-manager.Jobs():
+				if check := p.IsValid(); check != nil {
+					t.Fatalf("expected %v, got %v", tt.err, check)
+				}
 			}
-
 			manager.Stop()
+
 		})
 	}
 }

--- a/week06/manager_test.go
+++ b/week06/manager_test.go
@@ -1,0 +1,211 @@
+package week06
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestManager_Start(t *testing.T) {
+	t.Parallel()
+
+	//create new manager
+	manager := NewManager()
+
+	testcases := []struct {
+		name string
+		//m     *Manager
+		count int
+		err   error
+	}{
+		{
+			name:  "invalid employee count",
+			count: 0,
+			err:   ErrInvalidEmployeeCount(0),
+		},
+		{
+			name:  "valid employee count",
+			count: 1,
+			err:   nil,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+
+			go func() {
+				got := manager.Start(tt.count)
+				if got != nil {
+					manager.Errors() <- got
+					manager.Stop()
+				}
+			}()
+
+			for {
+				select {
+				case err := <-manager.Errors():
+					if err != nil {
+						if err.Error() != tt.err.Error() {
+							t.Fatalf("expected %v, got %v", tt.err, err)
+						}
+					}
+				case <-manager.Done():
+					return
+				}
+			}
+
+		})
+	}
+}
+
+func TestManager_Assign(t *testing.T) {
+	t.Parallel()
+
+	//Create new manager & stop the manager from further work
+	m := NewManager()
+	m.Stop()
+
+	fakeProduct := Product{}
+
+	readyProduct := Product{Quantity: 1}
+	readyProduct.Build(0)
+
+	fullProduct := Product{Quantity: 1}
+	fullProduct.Build(1)
+
+	testcases := []struct {
+		name     string
+		manager  *Manager
+		products *Product
+		err      error
+	}{
+		{
+			name:     "manager stopped",
+			manager:  m,
+			products: &fakeProduct,
+			err:      ErrManagerStopped{},
+		},
+		{
+			name:     "manager working, invalid products quantity",
+			manager:  NewManager(),
+			products: &fakeProduct,
+			err:      ErrInvalidQuantity(0),
+		},
+		{
+			name:     "manager working, invalid employee",
+			manager:  NewManager(),
+			products: &readyProduct,
+			err:      ErrInvalidEmployee(Employee(0)),
+		},
+		{
+			name:     "manager working, valid products",
+			manager:  NewManager(),
+			products: &fullProduct,
+			err:      nil,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+
+			err := tt.manager.Start(1)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got := tt.manager.Assign(tt.products)
+			if got != nil {
+				if got.Error() != tt.err.Error() {
+					t.Fatalf("expected %v, got %v", tt.err, got)
+				}
+				tt.manager.Stop()
+			}
+			tt.manager.Stop()
+		})
+	}
+}
+
+func TestManager_Complete(t *testing.T) {
+	t.Parallel()
+
+	manager := NewManager()
+
+	fakeProduct := Product{}
+
+	readyProduct := Product{Quantity: 1}
+	readyProduct.Build(0)
+
+	completeProduct := readyProduct
+	completeProduct.Build(1)
+
+	testcases := []struct {
+		name     string
+		employee int
+		product  *Product
+		err      error
+	}{
+		{
+			name:     "invalid employee",
+			employee: -1,
+			product:  &fakeProduct,
+			err:      ErrInvalidEmployee(-1),
+		},
+		{
+			name:     "invalid product, zero quantity",
+			employee: 1,
+			product:  &fakeProduct,
+			err:      ErrInvalidQuantity(0),
+		},
+		{
+			name:     "invalid product, not build",
+			employee: 1,
+			product:  &readyProduct,
+			err:      ErrProductNotBuilt(fmt.Sprintf("product is not built: %v", readyProduct)),
+		},
+		{
+			name:     "complete product ready for dispatch",
+			employee: 1,
+			product:  &completeProduct,
+			err:      nil,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+
+			err := manager.Start(1)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			go func() {
+
+				got := manager.Complete(Employee(tt.employee), tt.product)
+				if got != nil {
+					manager.Errors() <- got
+					return
+				}
+
+			}()
+
+			go func() {
+				cp := <-manager.Completed()
+				if check := cp.IsValid(); check == nil {
+					manager.Stop()
+				}
+			}()
+
+			for {
+				select {
+				case err := <-manager.Errors():
+					if err.Error() != tt.err.Error() {
+						t.Fatalf("expected %v, got %v", tt.err, err)
+					}
+					return
+				case <-manager.Done():
+					return
+				}
+			}
+		})
+	}
+
+}

--- a/week06/product.go
+++ b/week06/product.go
@@ -1,0 +1,69 @@
+package week06
+
+import (
+	"fmt"
+	"time"
+)
+
+// Product to be built by an employee
+type Product struct {
+	Quantity int
+
+	// non-exported fields (PRIVATE)
+	// !YOU MAY NOT ACCESS THESE FIELDS IN YOUR TESTS!
+	builtBy Employee
+}
+
+// BuiltBy returns the employee that built the product.
+// A return value of "0" means no employee has built the product yet.
+func (p Product) BuiltBy() Employee {
+	return p.builtBy
+}
+
+// Build builds the product by the given employee.
+// Returns an error if the product has already been built.
+// Returns an error if the employee ID <= 0.
+// Returns an error if the quantity <= 0.
+func (p *Product) Build(e Employee) error {
+	// error check
+
+	if err := p.IsValid(); err != nil {
+		return err
+	}
+
+	if err := e.IsValid(); err != nil {
+		return err
+	}
+
+	// build the product here
+	time.Sleep(time.Millisecond * time.Duration(p.Quantity))
+
+	// mark the product as built
+	p.builtBy = e
+
+	return nil
+}
+
+// IsValid returns an error if the product is invalid.
+// A valid product has a quantity > 0.
+func (p Product) IsValid() error {
+	if p.Quantity <= 0 {
+		return ErrInvalidQuantity(p.Quantity)
+	}
+
+	return nil
+}
+
+// IsBuilt returns an error if the product is not built,
+// or if the product is invalid.
+func (p Product) IsBuilt() error {
+	if err := p.IsValid(); err != nil {
+		return err
+	}
+
+	if p.builtBy == 0 {
+		return ErrProductNotBuilt(fmt.Sprintf("product is not built: %v", p))
+	}
+
+	return nil
+}

--- a/week06/product_test.go
+++ b/week06/product_test.go
@@ -1,0 +1,121 @@
+package week06
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestProduct_BuiltBy(t *testing.T) {
+	t.Parallel()
+
+	fakeProduct := Product{}
+
+	myProduct := Product{Quantity: 1}
+	myProduct.Build(1)
+
+	got := myProduct.BuiltBy()
+	exp := Employee(1)
+
+	if got != exp {
+		t.Fatalf("expected %d, got %d", exp, got)
+	}
+
+	got = fakeProduct.BuiltBy()
+	exp = Employee(0)
+
+	if got != exp {
+		t.Fatalf("expected %d, got %d", exp, got)
+	}
+
+}
+
+func TestProduct_Build(t *testing.T) {
+	t.Parallel()
+
+	emptyProduct := Product{}
+	readyProduct := Product{Quantity: 1}
+
+	testcases := []struct {
+		name    string
+		product *Product
+		worker  Employee
+		err     error
+	}{
+		{
+			name:    "invalid product",
+			product: &emptyProduct,
+			worker:  Employee(1),
+			err:     ErrInvalidQuantity(emptyProduct.Quantity),
+		},
+		{
+			name:    "valid product, bad employee",
+			product: &readyProduct,
+			worker:  Employee(-1),
+			err:     ErrInvalidEmployee(Employee(-1)),
+		},
+		{
+			name:    "valid product, good employee",
+			product: &readyProduct,
+			worker:  Employee(1),
+			err:     nil,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.product.Build(tt.worker)
+			if got != nil {
+				if got.Error() != tt.err.Error() {
+					t.Fatalf("expected %v, got %v", tt.err, got)
+				}
+			}
+		})
+	}
+
+}
+
+func TestProduct_IsBuilt(t *testing.T) {
+	t.Parallel()
+
+	fakeProduct := Product{}
+
+	readyProduct := Product{Quantity: 1}
+	readyProduct.Build(0)
+
+	completeProduct := readyProduct
+	completeProduct.Build(1)
+
+	testcases := []struct {
+		name    string
+		product Product
+		err     error
+	}{
+		{
+			name:    "empty fake product",
+			product: fakeProduct,
+			err:     ErrInvalidQuantity(fakeProduct.Quantity),
+		},
+		{
+			name:    "ready product no worker",
+			product: readyProduct,
+			err:     ErrProductNotBuilt(fmt.Sprintf("product is not built: %v", readyProduct)),
+		},
+		{
+			name:    "complete product with worker",
+			product: completeProduct,
+			err:     nil,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.product.IsBuilt()
+			if got != nil {
+				if got.Error() != tt.err.Error() {
+					t.Fatalf("expected %v, got %v", tt.err, got)
+				}
+			}
+		})
+	}
+
+}

--- a/week06/product_test.go
+++ b/week06/product_test.go
@@ -8,19 +8,19 @@ import (
 func TestProduct_BuiltBy(t *testing.T) {
 	t.Parallel()
 
-	fakeProduct := Product{}
+	fake := Product{}
 
-	myProduct := Product{Quantity: 1}
-	myProduct.Build(1)
+	prod := Product{Quantity: 1}
+	prod.Build(1)
 
-	got := myProduct.BuiltBy()
+	got := prod.BuiltBy()
 	exp := Employee(1)
 
 	if got != exp {
 		t.Fatalf("expected %d, got %d", exp, got)
 	}
 
-	got = fakeProduct.BuiltBy()
+	got = fake.BuiltBy()
 	exp = Employee(0)
 
 	if got != exp {
@@ -33,7 +33,7 @@ func TestProduct_Build(t *testing.T) {
 	t.Parallel()
 
 	emptyProduct := Product{}
-	readyProduct := Product{Quantity: 1}
+	ready := Product{Quantity: 1}
 
 	testcases := []struct {
 		name    string
@@ -49,13 +49,13 @@ func TestProduct_Build(t *testing.T) {
 		},
 		{
 			name:    "valid product, bad employee",
-			product: &readyProduct,
+			product: &ready,
 			worker:  Employee(-1),
 			err:     ErrInvalidEmployee(Employee(-1)),
 		},
 		{
 			name:    "valid product, good employee",
-			product: &readyProduct,
+			product: &ready,
 			worker:  Employee(1),
 			err:     nil,
 		},
@@ -77,12 +77,12 @@ func TestProduct_Build(t *testing.T) {
 func TestProduct_IsBuilt(t *testing.T) {
 	t.Parallel()
 
-	fakeProduct := Product{}
+	fake := Product{}
 
-	readyProduct := Product{Quantity: 1}
-	readyProduct.Build(0)
+	ready := Product{Quantity: 1}
+	ready.Build(0)
 
-	completeProduct := readyProduct
+	completeProduct := ready
 	completeProduct.Build(1)
 
 	testcases := []struct {
@@ -92,13 +92,13 @@ func TestProduct_IsBuilt(t *testing.T) {
 	}{
 		{
 			name:    "empty fake product",
-			product: fakeProduct,
-			err:     ErrInvalidQuantity(fakeProduct.Quantity),
+			product: fake,
+			err:     ErrInvalidQuantity(fake.Quantity),
 		},
 		{
 			name:    "ready product no worker",
-			product: readyProduct,
-			err:     ErrProductNotBuilt(fmt.Sprintf("product is not built: %v", readyProduct)),
+			product: ready,
+			err:     ErrProductNotBuilt(fmt.Sprintf("product is not built: %v", ready)),
 		},
 		{
 			name:    "complete product with worker",


### PR DESCRIPTION
# Adds unit tests for a simple product factory application example

This PR adds unit tests for a simple product factory application example.  There is a _Manager_ that receives orders for _Products_. The _Manager_ assigns those products to an _Employee_ to build. When the _Employee_ finishes the _Product_ they send it to the _Manager_ who returns a _CompletedProduct_ back to the customer.

The _Manager_ makes use of goroutines and channels to carry out the various tasks. The basic sends and receives operations on the channels are blocking. The channels are also unbuffered.

The unit tests added are as follows:

**_TestCompletedProduct_IsValid_** - checks if CompleteProduct is built when assigned to an Employee by the Manager.

**_TestEmployee_IsValid_** - checks if an Employee is valid to be assigned Products by the Manager or a job.

**_TestProduct_BuiltBy_**  -  checks if the employee that built a Product is valid or not

**_TestProduct_Build_** -  checks if a product is built by  a given employee or else there is an error in the operation

**_TestProduct_IsBuilt_** - checks if a product is valid or was built correctly by the assigned Employee.

**_TestManager_Start_** - checks if employees have been created for the given count and if they have started listening for the jobs.

**_TestManager_Assign_** - checks if the Manager has assigned given products to employees.

**_TestManager_Complete_** -  checks if products and employees wrapped as CompletedProduct have been passed correctly to the Completed channel, ready for the Manager to dispatch to the customer.

## Changes Summary
- Added complete_product.go, errors.go, product.go, employee.go and manager.go
- Added complete_product._test.go, product_test.go, employee_test.go, and manager._test.go that have unit test functions
- Miscellaneous - formatting code

## Difficulties
- Initializing the manager by NewManager() for certain subtest cases running goroutines was bringing out issues i.e RACE DATA WARNING. This was seen in TestManager_Start and TestManager_Complete unit tests e.g

```
       testcases := []struct {
		name     string
		employee int
                m *Manager
		product  *Product
		err      error
	}{}
```

The remedy was to initialize the manager way before the test cases.

- Still reading further regarding Channels, the practical explanation is easy to grasp than the coding part :)

## Surprises

- RACE DATA WARNING. as mentioned above

- Sometimes `go test -v -cover` brings different results from running `go test -cover -v -race ./...`




