### PR TITLE
Week07

### DIFF
--- a/week07/completed_product.go
+++ b/week07/completed_product.go
@@ -1,0 +1,20 @@
+package week07
+
+// CompletedProduct represents a completed product
+type CompletedProduct struct {
+	Product  Product  // Built Product
+	Employee Employee // Employee who built the product
+}
+
+// IsValid returns true if the product has been built.
+func (cp CompletedProduct) IsValid() error {
+	if err := cp.Employee.IsValid(); err != nil {
+		return err
+	}
+
+	if err := cp.Product.IsBuilt(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/week07/completed_product_test.go
+++ b/week07/completed_product_test.go
@@ -1,0 +1,64 @@
+package week07
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestCompletedProduct_IsValid(t *testing.T) {
+
+	t.Parallel()
+
+	//Build a product of 1 Quantity for 1 Employee
+	prod := Product{Quantity: 1}
+	prod.Build(1)
+
+	//Employee
+	e := Employee(1)
+
+	//Different Complete Products for different scenarios
+	empty := CompletedProduct{}
+	noEmployee := CompletedProduct{Product: prod, Employee: Employee(0)}
+	notBuild := CompletedProduct{Product: Product{Quantity: 1}, Employee: e}
+	good := CompletedProduct{Product: prod, Employee: e}
+
+	testcases := []struct {
+		name string
+		cp   CompletedProduct
+		err  error
+	}{
+		{
+			name: "empty complete product",
+			cp:   empty,
+			err:  fmt.Errorf("invalid employee number: 0"),
+		},
+		{
+			name: "complete product no employee",
+			cp:   noEmployee,
+			err:  ErrInvalidEmployee(0),
+		},
+		{
+			name: "complete product no buildby",
+			cp:   notBuild,
+			err:  ErrProductNotBuilt("product is not built: {1 0}"),
+		},
+		{
+			name: "full complete product",
+			cp:   good,
+			err:  nil,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cp.IsValid()
+			if got != nil {
+				if got.Error() != tt.err.Error() {
+					t.Fatalf("expected %v, got %v", tt.err, got)
+					return
+				}
+			}
+		})
+	}
+
+}

--- a/week07/employee.go
+++ b/week07/employee.go
@@ -1,0 +1,57 @@
+package week07
+
+// Employee is a worker.
+type Employee int
+
+// IsValid returns an error if the employee is not valid.
+// A valid employee is greater than zero.
+//	valid: Employee(1)
+//	valid: Employee(2)
+//	invalid: Employee(0)
+//	invalid: Employee(-1)
+func (e Employee) IsValid() error {
+	if e > 0 {
+		return nil
+	}
+
+	return ErrInvalidEmployee(e)
+}
+
+// worker listens for work from the manager
+// and tries to complete it.
+func (e Employee) work(m *Manager) {
+
+	// Use an infinite loop so we can listen for the next
+	// message coming down a channel.
+	// Without an infinite loop, the select statement
+	// would process the first channel with a message
+	// and then exit.
+	for {
+
+		// listen for messages on different channels
+		select {
+		case <-m.Done(): // listen for the manager to signal that it is done
+			return
+		case p, ok := <-m.Jobs(): // listen for a new job
+
+			// check if the channel is closed or not
+			if !ok {
+				continue
+			}
+
+			// try to build the product
+			err := p.Build(e)
+
+			if err != nil {
+				// if there is an error, send it to the manager
+				m.Errors() <- err
+				continue
+			}
+
+			// if there is no error, send the product back to the manager
+			m.Complete(e, p)
+
+		}
+	}
+
+}

--- a/week07/employee.go
+++ b/week07/employee.go
@@ -1,5 +1,7 @@
 package week07
 
+import "context"
+
 // Employee is a worker.
 type Employee int
 
@@ -19,7 +21,7 @@ func (e Employee) IsValid() error {
 
 // worker listens for work from the manager
 // and tries to complete it.
-func (e Employee) work(m *Manager) {
+func (e Employee) work(ctx context.Context, m *Manager) {
 
 	// Use an infinite loop so we can listen for the next
 	// message coming down a channel.
@@ -30,7 +32,7 @@ func (e Employee) work(m *Manager) {
 
 		// listen for messages on different channels
 		select {
-		case <-m.Done(): // listen for the manager to signal that it is done
+		case <-ctx.Done(): // listen for the manager to signal that it is done
 			return
 		case p, ok := <-m.Jobs(): // listen for a new job
 

--- a/week07/employee_test.go
+++ b/week07/employee_test.go
@@ -1,0 +1,60 @@
+package week07
+
+import (
+	"context"
+	"testing"
+)
+
+func TestEmployee_work(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name     string
+		employee Employee
+		err      error
+	}{
+		{
+			name:     "bad employee",
+			employee: Employee(0),
+			err:      ErrInvalidEmployee(0),
+		},
+		{
+			name:     "good employee",
+			employee: Employee(1),
+			err:      nil,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			manager := NewManager()
+			//defer manager.Stop()
+
+			prod := Product{Quantity: 1}
+
+			go tt.employee.work(ctx, manager)
+
+			err := manager.Assign(&prod)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			select {
+			case err := <-manager.Errors():
+				if err.Error() != tt.err.Error() {
+					t.Fatalf("expected %v, got %v", tt.err, err)
+				}
+				return
+			case cp := <-manager.Completed():
+				if check := cp.IsValid(); check != nil {
+					t.Fatalf("expected %v, got %v", tt.err, cp)
+				}
+			}
+
+		})
+	}
+}

--- a/week07/errors.go
+++ b/week07/errors.go
@@ -1,0 +1,45 @@
+package week07
+
+import "fmt"
+
+// ErrInvalidQuantity is returned when the product quantity is invalid.
+type ErrInvalidQuantity int
+
+func (e ErrInvalidQuantity) Error() string {
+	return fmt.Sprintf("quantity must be greater than 0, got %d", e)
+}
+
+// ---
+
+// ErrProductNotBuilt is returned when the product is not built.
+type ErrProductNotBuilt string
+
+func (e ErrProductNotBuilt) Error() string {
+	return string(e)
+}
+
+// ---
+
+// ErrInvalidEmployee is returned when the employee number is invalid.
+type ErrInvalidEmployee int
+
+func (e ErrInvalidEmployee) Error() string {
+	return fmt.Sprintf("invalid employee number: %d", e)
+}
+
+// ---
+
+// ErrInvalidEmployeeCount is returned when the employee count is invalid.
+type ErrInvalidEmployeeCount int
+
+func (e ErrInvalidEmployeeCount) Error() string {
+	return fmt.Sprintf("invalid employee count: %d", e)
+}
+
+// ---
+
+type ErrManagerStopped struct{}
+
+func (ErrManagerStopped) Error() string {
+	return "manager is stopped"
+}

--- a/week07/manager.go
+++ b/week07/manager.go
@@ -1,0 +1,162 @@
+package week07
+
+import "context"
+
+// Manager is responsible for receiving product orders
+// and assigning them to employees. Manager is also responsible
+// for receiving completed products, and listening for errors,
+// from employees. Manager takes products that have been built
+// by employees and returns them to the customer as a CompletedProduct.
+type Manager struct {
+	// non-exported fields (PRIVATE)
+	// !YOU MAY NOT ACCESS THESE FIELDS IN YOUR TESTS!
+	completed chan CompletedProduct
+	errs      chan error
+	jobs      chan *Product
+	quit      chan struct{}
+	stopped   bool
+}
+
+// NewManager will create a new Manager.
+// This function should ALWAYS be used to
+// create a new Manager.
+func NewManager() *Manager {
+	return &Manager{
+		completed: make(chan CompletedProduct),
+		errs:      make(chan error),
+		jobs:      make(chan *Product),
+		quit:      make(chan struct{}),
+	}
+}
+
+// Start will create new employees for the given count,
+// and start listening for jobs and errors.
+// Managers should be stopped using the Stop method
+// when they are no longer needed.
+func (m *Manager) Start(count int) error {
+
+	if count <= 0 {
+		return ErrInvalidEmployeeCount(count)
+	}
+
+	for i := 0; i < count; i++ {
+
+		e := Employee(i + 1)
+		go e.work(m)
+	}
+
+	return nil
+}
+
+// Assign will assign the given products to employees
+// as employeess become available. An invalid product
+// will return an error.
+func (m *Manager) Assign(products ...*Product) error {
+	if m.stopped {
+		return ErrManagerStopped{}
+	}
+
+	// loop through each product and assign it to an employee
+	for _, p := range products {
+		// validate product
+		if err := p.IsValid(); err != nil {
+			return err
+		}
+
+		// assign product to employee
+		// this will block until an employee becomes available
+		m.Jobs() <- p
+	}
+
+	return nil
+}
+
+// Complete will wrap the employee and the product into
+// a CompletedProduct. The will be passed down the Completed()
+// channel as soon as a listener is available to receive it.
+// Complete will error if the employee is invalid or
+// if the product is not built.
+func (m *Manager) Complete(e Employee, p *Product) error {
+	// validate employee
+	if err := e.IsValid(); err != nil {
+		return err
+	}
+
+	// validate product is built
+	if err := p.IsBuilt(); err != nil {
+		return err
+	}
+
+	cp := CompletedProduct{
+		Employee: e,
+		Product:  *p, // deference pointer to value type ype t
+	}
+
+	// Send completed product to Completed() channel
+	// for a listener to receive it.
+	// This will block until a listener is available.
+	m.completedCh() <- cp
+
+	return nil
+}
+
+// completedCh returns the channel for CompletedProducts
+func (m *Manager) completedCh() chan CompletedProduct {
+	return m.completed
+}
+
+// Completed will return a channel that can be listened to
+// for CompletedProducts.
+// This is a read-only channel.
+func (m *Manager) Completed() <-chan CompletedProduct {
+	return m.completedCh()
+}
+
+// Done will return a channel that will be closed
+// when the manager has stopped.
+// Employees should listen to this channel to know
+// when to stop listening for jobs.
+func (m *Manager) Done() <-chan struct{} {
+	return m.quit
+}
+
+// Jobs will return a channel that can be listened to
+// for new products to be built.
+func (m *Manager) Jobs() chan *Product {
+	return m.jobs
+}
+
+// Errors will return a channel that can be listened to
+// and can be used to receive errors from employees.
+func (m *Manager) Errors() chan error {
+	return m.errs
+}
+
+// Stop will stop the manager and clean up all resources.
+func (m *Manager) Stop() {
+	if m.stopped {
+		return
+	}
+
+	m.stopped = true
+
+	// close all channels
+	close(m.quit)
+	close(m.jobs)
+	close(m.errs)
+}
+
+// snippet: example
+func Run(ctx context.Context, count int, products ...*Product) ([]CompletedProduct, error) {
+	// NOTE: this function should not be the one to create
+	// the necessary contexts, time outs, signals, etc.
+	// The Run method should not care about those concerns,
+	// only its own.
+
+	// TODO: implement this function
+	// This function should run the manager with the given products
+	// and return the results.
+	return nil, nil
+}
+
+// snippet: example

--- a/week07/manager_test.go
+++ b/week07/manager_test.go
@@ -1,0 +1,21 @@
+package week07
+
+import (
+	"testing"
+)
+
+// snippet: example
+// TODO: Implement test cases for the Run function.
+func Test_Run(t *testing.T) {
+	t.Parallel()
+
+	// Tests you will need to write:
+
+	// TODO: timeout after 5 seconds if nothing happens
+	// TODO: interruption by a signal
+	// TODO: Run returns when the products are completed
+	// TODO: test that the output is correct
+
+}
+
+// snippet: example

--- a/week07/manager_test.go
+++ b/week07/manager_test.go
@@ -3,8 +3,6 @@ package week07
 import (
 	"context"
 	"fmt"
-	"os/signal"
-	"syscall"
 	"testing"
 	"time"
 )
@@ -105,49 +103,6 @@ func TestManager_Run(t *testing.T) {
 
 	})
 
-}
-
-const TEST_SIGNAL = syscall.SIGUSR2
-
-func TestManager_Run_Signals(t *testing.T) {
-	t.Run("interruption by a signal", func(t *testing.T) {
-
-		shirt := &Product{Quantity: 1}
-		cap := &Product{Quantity: 2}
-		short := &Product{Quantity: 1}
-
-		count := 3
-
-		ctx := context.Background()
-
-		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-		defer cancel()
-
-		sigCtx, cancel := signal.NotifyContext(ctx, TEST_SIGNAL)
-		defer cancel()
-
-		go Run(ctx, count, shirt, cap, short)
-
-		go func() {
-			time.Sleep(time.Second)
-			syscall.Kill(syscall.Getpid(), TEST_SIGNAL)
-		}()
-
-		select {
-		case <-ctx.Done():
-		case <-sigCtx.Done():
-			return
-		}
-
-		err := ctx.Err()
-		if err == nil {
-			return
-		}
-
-		if err == context.DeadlineExceeded {
-			t.Fatal("unexpected error", err)
-		}
-	})
 }
 
 func TestManager_Assign_Stop(t *testing.T) {

--- a/week07/manager_test.go
+++ b/week07/manager_test.go
@@ -3,6 +3,8 @@ package week07
 import (
 	"context"
 	"fmt"
+	"os/signal"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -105,23 +107,50 @@ func TestManager_Run(t *testing.T) {
 
 }
 
-/*
 const TEST_SIGNAL = syscall.SIGUSR2
 
 func TestManager_Run_Signals(t *testing.T) {
 	t.Run("interruption by a signal", func(t *testing.T) {
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		shirt := &Product{Quantity: 1}
+		cap := &Product{Quantity: 2}
+		short := &Product{Quantity: 1}
+
+		count := 3
+
+		ctx := context.Background()
+
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
 
 		sigCtx, cancel := signal.NotifyContext(ctx, TEST_SIGNAL)
 		defer cancel()
+
+		go Run(ctx, count, shirt, cap, short)
+
+		go func() {
+			time.Sleep(time.Second)
+			syscall.Kill(syscall.Getpid(), TEST_SIGNAL)
+		}()
+
+		select {
+		case <-ctx.Done():
+		case <-sigCtx.Done():
+			return
+		}
+
+		err := ctx.Err()
+		if err == nil {
+			return
+		}
+
+		if err == context.DeadlineExceeded {
+			t.Fatal("unexpected error", err)
+		}
 	})
 }
 
-*/
-
-func TestManager_Assign_ManagerStop(t *testing.T) {
+func TestManager_Assign_Stop(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -145,7 +174,7 @@ func TestManager_Assign_ManagerStop(t *testing.T) {
 
 }
 
-func TestManager_Complete_ManagerStop(t *testing.T) {
+func TestManager_Complete_Stop(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/week07/manager_test.go
+++ b/week07/manager_test.go
@@ -1,21 +1,258 @@
 package week07
 
 import (
+	"context"
+	"fmt"
 	"testing"
+	"time"
 )
 
-// snippet: example
-// TODO: Implement test cases for the Run function.
-func Test_Run(t *testing.T) {
+func TestManager_Run(t *testing.T) {
 	t.Parallel()
 
-	// Tests you will need to write:
+	t.Run("timeout after 5 seconds if nothing happens", func(t *testing.T) {
 
-	// TODO: timeout after 5 seconds if nothing happens
-	// TODO: interruption by a signal
-	// TODO: Run returns when the products are completed
-	// TODO: test that the output is correct
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		//A product with large quantity that will take more than 5 secs to process
+		prod := &Product{Quantity: 10000}
+
+		exp := context.DeadlineExceeded.Error()
+
+		_, err := Run(ctx, 1, prod)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		<-ctx.Done()
+
+		if ctx.Err().Error() != exp {
+			t.Fatalf("unexpected value, got: %v, exp: %v", ctx.Err().Error(), exp)
+		}
+
+	})
+
+	t.Run("invalid product quantity", func(t *testing.T) {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		count := 1
+		prod := &Product{Quantity: 0}
+		exp := ErrInvalidQuantity(0)
+
+		cp, err := Run(ctx, count, prod)
+
+		if err != nil {
+			if err.Error() != exp.Error() {
+				t.Fatalf("unexpected value, got: %v, exp: %v", err, exp)
+			}
+		}
+
+		if cp != nil {
+			t.Fatalf("unexpected value, got: %v, exp: %v", cp, nil)
+		}
+
+	})
+
+	t.Run("invalid employee count", func(t *testing.T) {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		count := 0
+		prod := &Product{Quantity: 1}
+		exp := ErrInvalidEmployeeCount(0)
+
+		cp, err := Run(ctx, count, prod)
+
+		if err != nil {
+			if err.Error() != exp.Error() {
+				t.Fatalf("unexpected value, got: %v, exp: %v", err, exp)
+			}
+		}
+
+		if cp != nil {
+			t.Fatalf("unexpected value, got: %v, exp: %v", cp, nil)
+		}
+
+	})
+
+	t.Run("test that the output is correct", func(t *testing.T) {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		shirt := &Product{Quantity: 1}
+		cap := &Product{Quantity: 2}
+		short := &Product{Quantity: 1}
+
+		count := 3
+
+		cp, err := Run(ctx, count, shirt, cap, short)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if count != len(cp) {
+			t.Fatalf("unexpected value, got: %v, exp: %v", len(cp), count)
+		}
+
+	})
 
 }
 
-// snippet: example
+/*
+const TEST_SIGNAL = syscall.SIGUSR2
+
+func TestManager_Run_Signals(t *testing.T) {
+	t.Run("interruption by a signal", func(t *testing.T) {
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		sigCtx, cancel := signal.NotifyContext(ctx, TEST_SIGNAL)
+		defer cancel()
+	})
+}
+
+*/
+
+func TestManager_Assign_ManagerStop(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Create new manager & stop the manager from further work
+	manager := NewManager()
+	manager.Start(ctx, 1)
+	manager.Stop()
+
+	fake := Product{}
+	exp := ErrManagerStopped{}
+
+	got := manager.Assign(&fake)
+	if got != nil {
+		if got.Error() != exp.Error() {
+			t.Fatalf("expected %v, got %v", exp, got)
+			return
+		}
+	}
+
+}
+
+func TestManager_Complete_ManagerStop(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Create new manager & stop the manager from further work
+	manager := NewManager()
+	manager.Start(ctx, 1)
+	manager.Stop()
+
+	ready := Product{Quantity: 1}
+	ready.Build(1)
+
+	exp := ErrManagerStopped{}
+
+	got := manager.Complete(Employee(1), &ready)
+	if got != nil {
+		if got.Error() != exp.Error() {
+			t.Fatalf("expected %v, got %v", exp, got)
+			return
+		}
+	}
+
+}
+
+func TestManager_Complete(t *testing.T) {
+	t.Parallel()
+
+	fake := Product{}
+
+	ready := Product{Quantity: 1}
+	ready.Build(0)
+
+	complete := ready
+	complete.Build(1)
+
+	testcases := []struct {
+		name     string
+		employee int
+		product  *Product
+		err      error
+	}{
+		{
+			name:     "invalid employee",
+			employee: -1,
+			product:  &fake,
+			err:      ErrInvalidEmployee(-1),
+		},
+		{
+			name:     "invalid product, zero quantity",
+			employee: 1,
+			product:  &fake,
+			err:      ErrInvalidQuantity(0),
+		},
+		{
+			name:     "invalid product, not build",
+			employee: 1,
+			product:  &ready,
+			err:      ErrProductNotBuilt(fmt.Sprintf("product is not built: %v", ready)),
+		},
+		{
+			name:     "complete product ready for dispatch",
+			employee: 1,
+			product:  &complete,
+			err:      nil,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			manager := NewManager()
+
+			ctx, err := manager.Start(ctx, 1)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			go func() {
+				got := manager.Complete(Employee(tt.employee), tt.product)
+				if got != nil {
+					manager.Errors() <- got
+				}
+			}()
+
+			go func() {
+				cp := <-manager.Completed()
+				if check := cp.IsValid(); check == nil {
+					manager.Stop()
+				}
+			}()
+
+			for {
+				select {
+				case err := <-manager.Errors():
+					if err.Error() != tt.err.Error() {
+						t.Fatalf("expected %v, got %v", tt.err, err)
+					}
+					return
+				case <-ctx.Done():
+					return
+				}
+			}
+		})
+	}
+
+}

--- a/week07/product.go
+++ b/week07/product.go
@@ -1,0 +1,69 @@
+package week07
+
+import (
+	"fmt"
+	"time"
+)
+
+// Product to be built by an employee
+type Product struct {
+	Quantity int
+
+	// non-exported fields (PRIVATE)
+	// !YOU MAY NOT ACCESS THESE FIELDS IN YOUR TESTS!
+	builtBy Employee
+}
+
+// BuiltBy returns the employee that built the product.
+// A return value of "0" means no employee has built the product yet.
+func (p Product) BuiltBy() Employee {
+	return p.builtBy
+}
+
+// Build builds the product by the given employee.
+// Returns an error if the product has already been built.
+// Returns an error if the employee ID <= 0.
+// Returns an error if the quantity <= 0.
+func (p *Product) Build(e Employee) error {
+	// error check
+
+	if err := p.IsValid(); err != nil {
+		return err
+	}
+
+	if err := e.IsValid(); err != nil {
+		return err
+	}
+
+	// build the product here
+	time.Sleep(time.Millisecond * time.Duration(p.Quantity))
+
+	// mark the product as built
+	p.builtBy = e
+
+	return nil
+}
+
+// IsValid returns an error if the product is invalid.
+// A valid product has a quantity > 0.
+func (p Product) IsValid() error {
+	if p.Quantity <= 0 {
+		return ErrInvalidQuantity(p.Quantity)
+	}
+
+	return nil
+}
+
+// IsBuilt returns an error if the product is not built,
+// or if the product is invalid.
+func (p Product) IsBuilt() error {
+	if err := p.IsValid(); err != nil {
+		return err
+	}
+
+	if p.builtBy == 0 {
+		return ErrProductNotBuilt(fmt.Sprintf("product is not built: %v", p))
+	}
+
+	return nil
+}

--- a/week07/product_test.go
+++ b/week07/product_test.go
@@ -1,0 +1,121 @@
+package week07
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestProduct_BuiltBy(t *testing.T) {
+	t.Parallel()
+
+	fake := Product{}
+
+	prod := Product{Quantity: 1}
+	prod.Build(1)
+
+	got := prod.BuiltBy()
+	exp := Employee(1)
+
+	if got != exp {
+		t.Fatalf("expected %d, got %d", exp, got)
+	}
+
+	got = fake.BuiltBy()
+	exp = Employee(0)
+
+	if got != exp {
+		t.Fatalf("expected %d, got %d", exp, got)
+	}
+
+}
+
+func TestProduct_Build(t *testing.T) {
+	t.Parallel()
+
+	emptyProduct := Product{}
+	ready := Product{Quantity: 1}
+
+	testcases := []struct {
+		name    string
+		product *Product
+		worker  Employee
+		err     error
+	}{
+		{
+			name:    "invalid product",
+			product: &emptyProduct,
+			worker:  Employee(1),
+			err:     ErrInvalidQuantity(emptyProduct.Quantity),
+		},
+		{
+			name:    "valid product, bad employee",
+			product: &ready,
+			worker:  Employee(-1),
+			err:     ErrInvalidEmployee(Employee(-1)),
+		},
+		{
+			name:    "valid product, good employee",
+			product: &ready,
+			worker:  Employee(1),
+			err:     nil,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.product.Build(tt.worker)
+			if got != nil {
+				if got.Error() != tt.err.Error() {
+					t.Fatalf("expected %v, got %v", tt.err, got)
+				}
+			}
+		})
+	}
+
+}
+
+func TestProduct_IsBuilt(t *testing.T) {
+	t.Parallel()
+
+	fake := Product{}
+
+	ready := Product{Quantity: 1}
+	ready.Build(0)
+
+	completeProduct := ready
+	completeProduct.Build(1)
+
+	testcases := []struct {
+		name    string
+		product Product
+		err     error
+	}{
+		{
+			name:    "empty fake product",
+			product: fake,
+			err:     ErrInvalidQuantity(fake.Quantity),
+		},
+		{
+			name:    "ready product no worker",
+			product: ready,
+			err:     ErrProductNotBuilt(fmt.Sprintf("product is not built: %v", ready)),
+		},
+		{
+			name:    "complete product with worker",
+			product: completeProduct,
+			err:     nil,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.product.IsBuilt()
+			if got != nil {
+				if got.Error() != tt.err.Error() {
+					t.Fatalf("expected %v, got %v", tt.err, got)
+				}
+			}
+		})
+	}
+
+}

--- a/week07/signal_linux_test.go
+++ b/week07/signal_linux_test.go
@@ -1,0 +1,52 @@
+package week07
+
+import (
+	"context"
+	"os/signal"
+	"syscall"
+	"testing"
+	"time"
+)
+
+const TEST_SIGNAL = syscall.SIGUSR2
+
+func TestManager_Run_Signals(t *testing.T) {
+	t.Run("interruption by a signal", func(t *testing.T) {
+
+		shirt := &Product{Quantity: 1}
+		cap := &Product{Quantity: 2}
+		short := &Product{Quantity: 1}
+
+		count := 3
+
+		ctx := context.Background()
+
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		sigCtx, cancel := signal.NotifyContext(ctx, TEST_SIGNAL)
+		defer cancel()
+
+		go Run(ctx, count, shirt, cap, short)
+
+		go func() {
+			time.Sleep(time.Second)
+			syscall.Kill(syscall.Getpid(), TEST_SIGNAL)
+		}()
+
+		select {
+		case <-ctx.Done():
+		case <-sigCtx.Done():
+			return
+		}
+
+		err := ctx.Err()
+		if err == nil {
+			return
+		}
+
+		if err == context.DeadlineExceeded {
+			t.Fatal("unexpected error", err)
+		}
+	})
+}

--- a/week07/signal_test.go
+++ b/week07/signal_test.go
@@ -1,3 +1,6 @@
+//go:build linux || darwin
+// +build linux darwin
+
 package week07
 
 import (


### PR DESCRIPTION
# Adds Run function, context, and unit tests for our simple product factory application example

This PR adds the _Run_ function to our simple product app. The _Run_ function starts the Manager and waits for all of the products to be built before returning. The PR also adds a _context.Context_  that deals with signal cancellation and timeouts, unit tests for the Run function, and modified unit tests.  The _context.Context_ is added in the Start function and returns a context that can be listed across the app.


The unit tests added/modified are as follows:

**_TestProduct_BuiltBy_**  -  checks if the employee that built a Product is valid or not

**_TestProduct_Build_** -  checks if a product is built by  a given employee or else there is an error in the operation

**_TestProduct_IsBuilt_** - checks if a product is valid or was built correctly by the assigned Employee.

**_TestManager_Run_** -  checks if the completed products are created correctly by the number of provided employees and products.

**_TestManager_Assign_Stop_** - checks if the Manager is able to stop before any assignment takes place.

**_TestManager_Assign_Complete_** - checks if the Manager is able to stop before any completed products are produced/completed.

**_TestManager_Complete_** -  checks if products and employees wrapped as CompletedProduct have been passed correctly to the Completed channel, ready for the Manager to dispatch to the customer.

_**TestManager_Run_Signals**_ - checks if signal interruption works when we run the Run function. This test only runs/work on Linux and Mac Os machines. It can't run on Windows due to _syscall_ package limitation. The _syscall_ package is dependent on the operating system. _syscall.Kill_, _syscall.SIGUSR2_ are for Unix/Linux/Mac systems, not Windows.

## Changes Summary
- Added Run function in manager.go and its unit test.
- Added context.Context to the Manager functionality in the Start function.
- Added signal_test.go for signal interruption unit tests on Linux + Mac Os machines.
- Miscellaneous - formatting code

## Difficulties
- Testing interruption by a signal gave me a hard time as  syscall.SIGUSR2 or syscall.SIGUSR1 can not be found in Windows machines:

`SIGUSR2 not declared by package syscall compiler UndeclaredImportedName`

`SIGUSR1 not declared by package syscall compiler UndeclaredImportedName`

The syscall package is dependent on the operating system. syscall.Kill, syscall.SIGUSR2 are for Unix/Linux/Mac systems, not Windows.

## Surprises
Go provides a mechanism to exclude certain source files when compiling by architecture or OS.
- By using [build constraints](https://pkg.go.dev/go/build#hdr-Build_Constraints), in my case I wanted signal_test.go to only run on Linux + Mac OS. On top of the file I used:
`// +build linux darwin`
- By using file suffixes:
`signal_linux_test.go // only builds on linux`





