### PR TITLE
Week08

### DIFF
--- a/week08/completed_product.go
+++ b/week08/completed_product.go
@@ -1,0 +1,20 @@
+package week08
+
+// CompletedProduct represents a completed product
+type CompletedProduct struct {
+	Product  Product  // Built Product
+	Employee Employee // Employee who built the product
+}
+
+// IsValid returns true if the product has been built.
+func (cp CompletedProduct) IsValid() error {
+	if err := cp.Employee.IsValid(); err != nil {
+		return err
+	}
+
+	if err := cp.Product.IsBuilt(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/week08/completed_product_test.go
+++ b/week08/completed_product_test.go
@@ -1,0 +1,44 @@
+package week08
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestCompletedProduct_IsValid(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name string
+		cp   CompletedProduct
+		err  error
+	}{
+		{
+			name: "invalid employee",
+			cp: CompletedProduct{
+				Product:  Product{Materials: Materials{Oil: 1}},
+				Employee: Employee(0),
+			},
+			err: ErrInvalidEmployee(0),
+		},
+		{
+			name: "not built",
+			cp: CompletedProduct{
+				Product:  Product{Materials: Materials{Oil: 2}},
+				Employee: Employee(1),
+			},
+			err: ErrProductNotBuilt(fmt.Sprintf("product is not built: %v", &Product{Materials: Materials{Oil: 2}})),
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cp.IsValid()
+			if err != nil {
+				if err.Error() != tt.err.Error() {
+					t.Fatalf("expected %v, got %v", tt.err, err)
+				}
+			}
+		})
+	}
+}

--- a/week08/employee.go
+++ b/week08/employee.go
@@ -1,0 +1,60 @@
+package week08
+
+import (
+	"context"
+)
+
+// Employee is a worker.
+type Employee int
+
+// IsValid returns an error if the employee is not valid.
+// A valid employee is greater than zero.
+//	valid: Employee(1)
+//	valid: Employee(2)
+//	invalid: Employee(0)
+//	invalid: Employee(-1)
+func (e Employee) IsValid() error {
+	if e > 0 {
+		return nil
+	}
+
+	return ErrInvalidEmployee(e)
+}
+
+// worker listens for work from the manager
+// and tries to complete it.
+func (e Employee) work(ctx context.Context, m *Manager) {
+
+	// Use an infinite loop so we can listen for the next
+	// message coming down a channel.
+	// Without an infinite loop, the select statement
+	// would process the first channel with a message
+	// and then exit.
+	for {
+
+		// listen for messages on different channels
+		select {
+		case <-ctx.Done(): // listen context cancellation
+			return
+		case p, ok := <-m.Jobs(): // listen for a new job
+
+			// check if the channel is closed or not
+			if !ok {
+				continue
+			}
+
+			// try to build the product
+			err := p.Build(e, m.Warehouse)
+			if err != nil {
+				// if there is an error, send it to the manager
+				m.Errors() <- err
+				continue
+			}
+
+			// if there is no error, send the product back to the manager
+			m.Complete(e, p)
+
+		}
+	}
+
+}

--- a/week08/employee_test.go
+++ b/week08/employee_test.go
@@ -1,0 +1,63 @@
+package week08
+
+import (
+	"context"
+	"testing"
+)
+
+func TestEmployee_work(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name string
+		e    Employee
+		prod *Product
+		err  error
+	}{
+		{
+			name: "invalid employee",
+			e:    Employee(0),
+			prod: &Product{Materials: Materials{Wood: 2, Oil: 3}},
+			err:  ErrInvalidEmployee(0),
+		},
+		{
+			name: "valid employee",
+			prod: &Product{Materials: Materials{Wood: 1, Oil: 1}},
+			e:    Employee(1),
+			err:  nil,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+
+			ctx := context.Background()
+
+			manager := &Manager{}
+			manager.Warehouse = &Warehouse{}
+
+			go tt.e.work(ctx, manager)
+
+			err := manager.Assign(tt.prod)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			select {
+			case err := <-manager.Errors():
+				if err != nil {
+					if err.Error() != tt.err.Error() {
+						t.Fatalf("expected %v, got %v", tt.err, err)
+					}
+				}
+				return
+			case cp := <-manager.Completed():
+				if check := cp.IsValid(); check != nil {
+					t.Fatalf("expected %v, got %v", tt.err, cp)
+				}
+			}
+
+		})
+	}
+
+}

--- a/week08/errors.go
+++ b/week08/errors.go
@@ -1,0 +1,45 @@
+package week08
+
+import "fmt"
+
+// ErrInvalidMaterials is returned when the product materials quantity is invalid.
+type ErrInvalidMaterials int
+
+func (e ErrInvalidMaterials) Error() string {
+	return fmt.Sprintf("materials must be greater than 0, got %d", e)
+}
+
+// ---
+
+// ErrProductNotBuilt is returned when the product is not built.
+type ErrProductNotBuilt string
+
+func (e ErrProductNotBuilt) Error() string {
+	return string(e)
+}
+
+// ---
+
+// ErrInvalidEmployee is returned when the employee number is invalid.
+type ErrInvalidEmployee int
+
+func (e ErrInvalidEmployee) Error() string {
+	return fmt.Sprintf("invalid employee number: %d", e)
+}
+
+// ---
+
+// ErrInvalidEmployeeCount is returned when the employee count is invalid.
+type ErrInvalidEmployeeCount int
+
+func (e ErrInvalidEmployeeCount) Error() string {
+	return fmt.Sprintf("invalid employee count: %d", e)
+}
+
+// ---
+
+type ErrManagerStopped struct{}
+
+func (ErrManagerStopped) Error() string {
+	return "manager is stopped"
+}

--- a/week08/manager.go
+++ b/week08/manager.go
@@ -1,0 +1,183 @@
+package week08
+
+import (
+	"context"
+)
+
+// Manager is responsible for receiving product orders
+// and assigning them to employees. Manager is also responsible
+// for receiving completed products, and listening for errors,
+// from employees. Manager takes products that have been built
+// by employees and returns them to the customer as a CompletedProduct.
+type Manager struct {
+	Warehouse *Warehouse
+	cancel    context.CancelFunc
+	completed chan CompletedProduct
+	errs      chan error
+	jobs      chan *Product
+	stopped   bool
+}
+
+// Start will create new employees for the given count,
+// and start listening for jobs and errors.
+// Managers should be stopped using the Stop method
+// when they are no longer needed.
+func (m *Manager) Start(ctx context.Context, count int) (context.Context, error) {
+
+	if count <= 0 {
+		return nil, ErrInvalidEmployeeCount(count)
+	}
+
+	// create a new cancellation context
+	ctx, cancel := context.WithCancel(ctx)
+
+	// hold onto the cancel function so it can be called
+	// by m.Stop()
+	m.cancel = cancel
+
+	// launch a goroutine to listen context cancellation
+	go func() {
+
+		// listen for context cancellation
+		// this could come from the external context
+		// passed to m.Start()
+		<-ctx.Done()
+
+		// call the cancel function
+		cancel()
+
+		// call Stop()
+		m.Stop()
+	}()
+
+	if m.Warehouse == nil {
+		m.Warehouse = &Warehouse{}
+	}
+
+	// start the warehouse
+	// this returns a context that can be listened to
+	// for cancellation notification from the warehouse
+	ctx = m.Warehouse.Start(ctx)
+
+	for i := 0; i < count; i++ {
+
+		e := Employee(i + 1)
+
+		// start the employee working
+		// with the given context and manager
+		go e.work(ctx, m)
+	}
+
+	// return the context for clients to listen to
+	// for cancellation.
+	return ctx, nil
+}
+
+// Assign will assign the given products to employees
+// as employeess become available. An invalid product
+// will return an error.
+func (m *Manager) Assign(products ...*Product) error {
+	if m.stopped {
+		return ErrManagerStopped{}
+	}
+
+	// loop through each product and assign it to an employee
+	for _, p := range products {
+		// validate product
+		if err := p.IsValid(); err != nil {
+			return err
+		}
+
+		// assign product to employee
+		// this will block until an employee becomes available
+		m.Jobs() <- p
+	}
+
+	return nil
+}
+
+// Complete will wrap the employee and the product into
+// a CompletedProduct. The will be passed down the Completed()
+// channel as soon as a listener is available to receive it.
+// Complete will error if the employee is invalid or
+// if the product is not built.
+func (m *Manager) Complete(e Employee, p *Product) error {
+	// validate employee
+	if err := e.IsValid(); err != nil {
+		return err
+	}
+
+	// validate product is built
+	if err := p.IsBuilt(); err != nil {
+		return err
+	}
+
+	cp := CompletedProduct{
+		Employee: e,
+		Product:  *p, // deference pointer to value type ype t
+	}
+
+	// fmt.Printf("TODO >> manager.go:102 cp %[1]T %[1]v\n", cp)
+	// Send completed product to Completed() channel
+	// for a listener to receive it.
+	// This will block until a listener is available.
+	m.completedCh() <- cp
+
+	return nil
+}
+
+// completedCh returns the channel for CompletedProducts
+func (m *Manager) completedCh() chan CompletedProduct {
+	if m.completed == nil {
+		m.completed = make(chan CompletedProduct)
+	}
+	return m.completed
+}
+
+// Completed will return a channel that can be listened to
+// for CompletedProducts.
+// This is a read-only channel.
+func (m *Manager) Completed() <-chan CompletedProduct {
+	return m.completedCh()
+}
+
+// Jobs will return a channel that can be listened to
+// for new products to be built.
+func (m *Manager) Jobs() chan *Product {
+	if m.jobs == nil {
+		m.jobs = make(chan *Product)
+	}
+	return m.jobs
+}
+
+// Errors will return a channel that can be listened to
+// and can be used to receive errors from employees.
+func (m *Manager) Errors() chan error {
+	if m.errs == nil {
+		m.errs = make(chan error)
+	}
+	return m.errs
+}
+
+// Stop will stop the manager and clean up all resources.
+func (m *Manager) Stop() {
+	m.cancel()
+	if m.stopped {
+		return
+	}
+
+	m.stopped = true
+
+	// close all channels
+	if m.jobs != nil {
+		close(m.jobs)
+	}
+
+	if m.errs != nil {
+		close(m.errs)
+	}
+
+	if m.completed != nil {
+		close(m.completed)
+	}
+}

--- a/week08/manager.go
+++ b/week08/manager.go
@@ -65,16 +65,14 @@ func (m *Manager) Start(ctx context.Context, count int) (context.Context, error)
 	ctx = m.Warehouse.Start(ctx)
 	m.mu.Unlock()
 
-	m.mu.Lock()
 	for i := 0; i < count; i++ {
-
 		e := Employee(i + 1)
 
 		// start the employee working
 		// with the given context and manager
 		go e.work(ctx, m)
 	}
-	m.mu.Unlock()
+
 	// return the context for clients to listen to
 	// for cancellation.
 	return ctx, nil

--- a/week08/manager_test.go
+++ b/week08/manager_test.go
@@ -1,0 +1,193 @@
+package week08
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func TestManager_Start(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name  string
+		count int
+		err   error
+	}{
+		{
+			name:  "invalid employee count",
+			count: 0,
+			err:   ErrInvalidEmployeeCount(0),
+		},
+		{
+			name:  "valid employee",
+			count: 1,
+			err:   nil,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+
+			ctx := context.Background()
+			manager := &Manager{}
+
+			_, err := manager.Start(ctx, tt.count)
+			if err != nil {
+				if tt.err.Error() != err.Error() {
+					t.Fatalf("expected %v, got %v", tt.err, err)
+				}
+			}
+
+		})
+	}
+
+}
+
+func TestManager_Assign(t *testing.T) {
+	t.Parallel()
+
+	t.Run("manager stop", func(t *testing.T) {
+
+		ctx := context.Background()
+		exp := ErrManagerStopped{}
+
+		manager := &Manager{}
+
+		_, err := manager.Start(ctx, 1)
+		if err != nil {
+			t.Fatal("unexpected error")
+		}
+		manager.Stop()
+
+		err = manager.Assign(&Product{
+			Materials: Materials{
+				Wood: 2,
+				Oil:  3,
+			},
+		})
+
+		if err != nil {
+			if exp.Error() != err.Error() {
+				t.Fatalf("expected %v, got %v", exp, err)
+			}
+		}
+
+	})
+
+	testcases := []struct {
+		name string
+		prod *Product
+		err  error
+	}{
+		{
+			name: "invalid product",
+			prod: &Product{},
+			err:  ErrInvalidMaterials(0),
+		},
+		{
+			name: "valid product",
+			prod: &Product{Materials: Materials{Oil: 2}},
+			err:  nil,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+
+			ctx := context.Background()
+			manager := &Manager{}
+
+			_, err := manager.Start(ctx, 1)
+			if err != nil {
+				t.Fatal("unexpected error")
+			}
+
+			err = manager.Assign(tt.prod)
+			if err != nil {
+				if tt.err.Error() != err.Error() {
+					t.Fatalf("expected %v, got %v", tt.err, err)
+				}
+			}
+
+		})
+	}
+
+}
+
+func TestManager_Complete(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name string
+		e    Employee
+		p    *Product
+		err  error
+	}{
+		{
+			name: "invalid employee",
+			e:    Employee(0),
+			p:    &Product{Materials: Materials{Wood: 2}},
+			err:  ErrInvalidEmployee(0),
+		},
+		{
+			name: "invalid quantity",
+			e:    Employee(1),
+			p:    &Product{},
+			err:  ErrInvalidMaterials(0),
+		},
+		{
+			name: "invalid product",
+			e:    Employee(1),
+			p:    &Product{Materials: Materials{Oil: 1}, builtBy: 0},
+			err:  ErrProductNotBuilt(fmt.Sprintf("product is not built: %v", &Product{Materials: Materials{Oil: 1}, builtBy: 0})),
+		},
+		{
+			name: "valid product/employee",
+			e:    Employee(1),
+			p:    &Product{Materials: Materials{Wood: 2, Oil: 3}},
+			err:  nil,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+
+			ctx := context.Background()
+			manager := &Manager{}
+
+			manager.Start(ctx, 1)
+
+			tt.p.Build(tt.e, &Warehouse{})
+
+			go func() {
+				got := manager.Complete(Employee(tt.e), tt.p)
+				if got != nil {
+					manager.Errors() <- got
+				}
+			}()
+
+			go func() {
+				cp := <-manager.Completed()
+				if check := cp.IsValid(); check == nil {
+					manager.Stop()
+				}
+			}()
+
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case err := <-manager.Errors():
+					if err != nil {
+						if err.Error() != tt.err.Error() {
+							t.Fatalf("expected %v, got %v", tt.err, err)
+						}
+					}
+					return
+				}
+			}
+
+		})
+	}
+}

--- a/week08/material.go
+++ b/week08/material.go
@@ -1,0 +1,62 @@
+package week08
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	// some handy constants
+	Metal   Material = "metal"
+	Oil     Material = "oil"
+	Plastic Material = "plastic"
+	Wood    Material = "wood"
+)
+
+// Material is the type of material
+// that a product is made of.
+type Material string
+
+func (m Material) String() string {
+	return string(m)
+}
+
+// Duration is the amount of time it takes
+// to produce the given material.
+// This is based on the length of the
+// material string.
+// 	Material("metal").Duration() == 5ms
+// 	Material("oil").Duration() == 3ms
+// 	Material("plastic").Duration() == 7ms
+// 	Material("wood").Duration() == 4ms
+func (m Material) Duration() time.Duration {
+	i := len(m)
+	return time.Duration(i) * time.Millisecond
+}
+
+// Materials is a list of materials
+// and their quantities.
+type Materials map[Material]int
+
+// Duration is the amount of time it takes
+// to produce the given materials.
+func (mats Materials) Duration() time.Duration {
+	var d time.Duration
+	for m, q := range mats {
+		d += m.Duration() * time.Duration(q)
+	}
+	return d
+}
+
+func (mats Materials) String() string {
+	lines := make([]string, 0, len(mats))
+
+	for m, q := range mats {
+		lines = append(lines, fmt.Sprintf("{%s:%dx}", m, q))
+	}
+	sort.Strings(lines)
+	s := strings.Join(lines, ", ")
+	return fmt.Sprintf("[%s]", s)
+}

--- a/week08/material_test.go
+++ b/week08/material_test.go
@@ -1,0 +1,23 @@
+package week08
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMaterial_Duration(t *testing.T) {
+	t.Parallel()
+
+	mats := Materials{
+		Oil:  1,
+		Wood: 1,
+	}
+
+	exp := time.Duration(7) * time.Millisecond
+
+	got := mats.Duration()
+	if got != exp {
+		t.Fatalf("expected %v, got %v", exp, got)
+	}
+
+}

--- a/week08/product.go
+++ b/week08/product.go
@@ -1,0 +1,90 @@
+package week08
+
+import (
+	"fmt"
+)
+
+var (
+	ProductA = &Product{
+		Materials: Materials{
+			Wood: 2,
+			Oil:  3,
+		},
+	}
+
+	ProductB = &Product{
+		Materials: Materials{
+			Metal:   1,
+			Oil:     2,
+			Plastic: 3,
+			Wood:    4,
+		},
+	}
+)
+
+// Product to be built by an employee
+type Product struct {
+	Materials Materials
+
+	builtBy Employee
+}
+
+func (p Product) String() string {
+	return p.Materials.String()
+}
+
+// BuiltBy returns the employee that built the product.
+// A return value of "0" means no employee has built the product yet.
+func (p Product) BuiltBy() Employee {
+	return p.builtBy
+}
+
+// Build builds the product by the given employee.
+// Returns an error if the product is not valid
+// Returns an error if the product is already built
+// Returns an error if the employee is not valid
+func (p *Product) Build(e Employee, w *Warehouse) error {
+	// error check
+
+	if err := p.IsValid(); err != nil {
+		return err
+	}
+
+	if err := e.IsValid(); err != nil {
+		return err
+	}
+
+	// retrieve materials from warehouse
+	for k, v := range p.Materials {
+		w.Retrieve(k, v)
+	}
+
+	// mark the product as built
+	p.builtBy = e
+
+	return nil
+}
+
+// IsValid returns an error if the product is invalid.
+// A valid product has a quantity > 0.
+func (p Product) IsValid() error {
+	if len(p.Materials) == 0 {
+		return ErrInvalidMaterials(len(p.Materials))
+	}
+
+	return nil
+}
+
+// IsBuilt returns an error if the product is not built,
+// or if the product is invalid.
+func (p Product) IsBuilt() error {
+	if err := p.IsValid(); err != nil {
+		return err
+	}
+
+	if p.builtBy == 0 {
+		return ErrProductNotBuilt(fmt.Sprintf("product is not built: %v", p))
+	}
+
+	return nil
+}

--- a/week08/product.go
+++ b/week08/product.go
@@ -38,10 +38,7 @@ func (p *Product) Build(e Employee, w *Warehouse) error {
 
 	// retrieve materials from warehouse
 	for k, v := range p.Materials {
-		_, err := w.Retrieve(k, v)
-		if err != nil {
-			return err
-		}
+		w.Retrieve(k, v)
 	}
 
 	// mark the product as built

--- a/week08/product.go
+++ b/week08/product.go
@@ -4,24 +4,6 @@ import (
 	"fmt"
 )
 
-var (
-	ProductA = &Product{
-		Materials: Materials{
-			Wood: 2,
-			Oil:  3,
-		},
-	}
-
-	ProductB = &Product{
-		Materials: Materials{
-			Metal:   1,
-			Oil:     2,
-			Plastic: 3,
-			Wood:    4,
-		},
-	}
-)
-
 // Product to be built by an employee
 type Product struct {
 	Materials Materials

--- a/week08/product.go
+++ b/week08/product.go
@@ -56,7 +56,10 @@ func (p *Product) Build(e Employee, w *Warehouse) error {
 
 	// retrieve materials from warehouse
 	for k, v := range p.Materials {
-		w.Retrieve(k, v)
+		_, err := w.Retrieve(k, v)
+		if err != nil {
+			return err
+		}
 	}
 
 	// mark the product as built

--- a/week08/product_test.go
+++ b/week08/product_test.go
@@ -1,0 +1,27 @@
+package week08
+
+import "testing"
+
+func TestProduct_BuiltBy(t *testing.T) {
+	t.Parallel()
+
+	fake := Product{}
+
+	prod := Product{Materials: Materials{Oil: 2}}
+	prod.Build(1, &Warehouse{})
+
+	got := prod.BuiltBy()
+	exp := Employee(1)
+
+	if got != exp {
+		t.Fatalf("expected %d, got %d", exp, got)
+	}
+
+	got = fake.BuiltBy()
+	exp = Employee(0)
+
+	if got != exp {
+		t.Fatalf("expected %d, got %d", exp, got)
+	}
+
+}

--- a/week08/warehouse.go
+++ b/week08/warehouse.go
@@ -1,0 +1,73 @@
+package week08
+
+import (
+	"context"
+	"time"
+)
+
+// Warehouse is where the materials are stored
+// and where the materials are retrieved from
+type Warehouse struct {
+	cancel    context.CancelFunc // cancels the warehouse
+	cap       int                // capacity of the warehouse
+	materials Materials          // materials in the warehouse
+}
+
+// Start the warehouse
+func (w *Warehouse) Start(ctx context.Context) context.Context {
+	ctx, w.cancel = context.WithCancel(ctx)
+	return ctx
+}
+
+// Stop the warehouse
+func (w *Warehouse) Stop() {
+	w.cancel()
+}
+
+// Retrieve quantity of material from the warehouse
+func (w *Warehouse) Retrieve(m Material, q int) (Material, error) {
+	ctx := w.fill(m)
+
+	// wait for the materials to become available
+	<-ctx.Done()
+
+	// remove the materials from the warehouse
+	w.materials[m] -= q
+
+	return m, nil
+}
+
+// fill the warehouse with the material until it is full
+func (w *Warehouse) fill(m Material) context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// lauch a goroutine to fill the warehouse
+	// until it is full
+	// context is cancelled when the warehouse is full
+	go func() {
+		defer cancel()
+
+		if w.cap <= 0 {
+			w.cap = 10
+		}
+
+		if w.materials == nil {
+			w.materials = Materials{}
+		}
+
+		cap := w.cap
+		mats := w.materials
+
+		// until the warehouse is full of
+		// the material create the material and
+		// fill the warehouse
+		q := mats[m]
+		for q < cap {
+			time.Sleep(m.Duration())
+			mats[m]++
+			q = mats[m]
+		}
+	}()
+
+	return ctx
+}

--- a/week08/warehouse_test.go
+++ b/week08/warehouse_test.go
@@ -1,0 +1,23 @@
+package week08
+
+import (
+	"context"
+	"testing"
+)
+
+func TestWarehouse_Stop(t *testing.T) {
+	t.Parallel()
+
+	w := &Warehouse{}
+	ctx := context.Background()
+
+	exp := "context canceled"
+
+	ctx = w.Start(ctx)
+	w.Stop()
+
+	if ctx.Err().Error() != exp {
+		t.Fatalf("expected %v, got %v", exp, ctx.Err().Error())
+	}
+
+}


### PR DESCRIPTION
# Adding race condition fixes and unit tests for the enhanced example manager application
This PR fixes race conditions/data races that were reported when running the race detector against the code. It also adds unit tests for the various methods/functions where applicable.

The data races were fixed by the use of mutexes provided by the sync package. I used _sync.Mutex_ which I embedded in the required structs e.g

```
type Manager struct {
	........
	mu        sync.Mutex
}
```

Then I used Lock and Unlock methods to block and unblock write/read function calls that were causing data races.

For unit tests, I added:

**TestCompletedProduct_IsValid** - This test checks if the CompletedProduct is valid or not

**TestEmployee_work** - This test checks if a worker is able to complete jobs assigned by the manager.

**TestManager_Start** - checks if employees have been created for the given count and if they have started listening for the jobs.

**TestManager_Assign** - checks if the Manager has assigned given products to employees.

**TestManager_Complete** - checks if products and employees wrapped as CompletedProduct have been passed correctly to the Completed channel, ready for the Manager to dispatch to the customer.

**TestMaterial_Duration** - check if the amount of time it takes to produce the given materials is valid or not.

**TestProduct_BuiltBy** - checks if the employee that built a Product is valid or not.

**TestWarehouse_Stop** - checks if we can stop the warehouse correctly.

## Changes Summary
- Adding data races fixes
- Adding unit tests

## Difficulties
- I tried all my best but couldn't find a way to cover this section of code in my tests:
![image](https://user-images.githubusercontent.com/26469998/142781791-eab45ddd-9065-4451-8139-8ddf2ae61cec.png)

- I was getting weird/odd Product.Build() data race, which was due to the defined ProductA, ProductB variables. Once removed or defined new products on Assign method, all went well.

- Was wondering, is there a way to tell if you have overused Mutexes and thus are redundant in the code?

## Surprises
The sync package makes it easier to solve data races.
