### PR TITLE
Week09

### DIFF
--- a/week09/README.md
+++ b/week09/README.md
@@ -1,23 +1,7 @@
 # Newsmill
-
-A Go app implementing a topic-based publish-subscribe system using channels. 
-
-The Newsmill app have many sources for news content, and subscribers listening/reading to the multiple news stories.
-
-## Usage
-
-Run main.go:
-
-``go run cmd/news-mill/main.go
-```
-
-### Release v1.0 notes
-The app is still work in progress :)
-
-## Documentation
-
-## Tests
+<p><img src="https://user-images.githubusercontent.com/26469998/143808561-b43f5a60-695f-4375-ba1b-c1b3a97a6df8.png" alt="Newsmill" style="width: 200px;" align="right"></p>
 
 
-## Author
-The Newsmill app is coded by Anthony Webbs
+<p>Newsmill is a simple news service that collects news stories and publishes to users to choose from. A user only need to choose a topic/category! </p>
+
+

--- a/week09/README.md
+++ b/week09/README.md
@@ -1,0 +1,23 @@
+# Newsmill
+
+A Go app implementing a topic-based publish-subscribe system using channels. 
+
+The Newsmill app have many sources for news content, and subscribers listening/reading to the multiple news stories.
+
+## Usage
+
+Run main.go:
+
+``go run cmd/news-mill/main.go
+```
+
+### Release v1.0 notes
+The app is still work in progress :)
+
+## Documentation
+
+## Tests
+
+
+## Author
+The Newsmill app is coded by Anthony Webbs

--- a/week09/pkg/newsmill/errors.go
+++ b/week09/pkg/newsmill/errors.go
@@ -1,0 +1,1 @@
+package newsmill

--- a/week09/pkg/newsmill/service.go
+++ b/week09/pkg/newsmill/service.go
@@ -1,0 +1,63 @@
+package newsmill
+
+import (
+	"context"
+	"sync"
+)
+
+type NewsService struct {
+	sync.RWMutex
+	cancel      context.CancelFunc
+	stopped     bool
+	Subscribers map[string][]*Subscriber
+	//sources *Source
+}
+
+//Start
+func (ns *NewsService) Start(ctx context.Context) (context.Context, error) {
+
+	ctx, cancel := context.WithCancel(ctx)
+
+	ns.Lock()
+	ns.cancel = cancel
+	ns.Unlock()
+
+	return ctx, nil
+}
+
+//Subscribe will subscribe a subscriber to the news service
+func (ns *NewsService) Subscribe(ctx context.Context) error {
+	return nil
+}
+
+//UnSubscribe will unsubscribe a subscriber from the news service
+func (ns *NewsService) Unsubscribe(ctx context.Context) error {
+	return nil
+}
+
+/*
+//Read
+func (ns *NewsService) Read() {}
+
+//Stream
+func (ns *NewsService) Stream() {}
+
+//Clear
+func (ns *NewsService) Clear() {}
+*/
+
+//Stop will stop the news service and all resources
+//The resources include subscribers and news sources
+func (ns *NewsService) Stop() {
+
+	ns.Lock()
+	if ns.stopped {
+		ns.Unlock()
+		return
+	}
+	ns.Unlock()
+
+	ns.cancel()
+
+	ns.stopped = true
+}

--- a/week09/pkg/newsmill/source.go
+++ b/week09/pkg/newsmill/source.go
@@ -1,0 +1,55 @@
+package newsmill
+
+import (
+	"context"
+	"io"
+	"sync"
+	"time"
+)
+
+const (
+	File SourceType = "file"
+	Mock SourceType = "mock"
+	URL  SourceType = "url"
+)
+
+type SourceType string
+
+//The Source to publish stories for any category, or categories, they wish to define
+type Source struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	SourceType `json:"publishertype"`
+	sync.RWMutex
+	cancel context.CancelFunc
+	//stopped bool
+}
+
+//News story/article that is published by the Publisher
+type Article struct {
+	ID          int       `json:"id"`
+	Title       string    `json:"title"`
+	Author      string    `json:"author"`
+	Content     string    `json:"body"`
+	PublishedAt time.Time `json:"publishedAt"`
+	Category    []string  `json:"category"`
+}
+
+type Sources interface {
+	Publish(ctx context.Context, cat []string, r io.Reader) ([]*Article, error)
+	Stop()
+}
+
+func (s *Source) Publish(ctx context.Context, cat []string, r io.Reader) ([]Article, error) {
+
+	return nil, nil
+}
+
+func (s *Source) Stop() {
+	s.RLock()
+	defer s.RUnlock()
+
+	if s.cancel != nil {
+		s.cancel()
+	}
+}

--- a/week09/pkg/newsmill/subscriber.go
+++ b/week09/pkg/newsmill/subscriber.go
@@ -1,0 +1,41 @@
+package newsmill
+
+/*
+Subscribers should be able to receive news stories for the categories they are subscribed to.
+Subscribers should be able to subscribe to the news service and receive news stories for one or more categories.
+Subscribers should be able to unsubscribe from the news service. Other subscribers should not be affected.
+Subscribers should be cancelled by the news service when the news service is stopped.
+Subscribers should not be aware of each other, nor should they have any direct contact with the news sources.
+Subscribers should not be effected by the removal of a news source.
+*/
+
+//Subscriber to subscribe to news stories category/categories
+type Subscriber struct {
+	ID       int
+	Email    string
+	Category []Category
+}
+
+//News stories categories to subscribe
+type Category struct {
+	Name string
+}
+
+func (s *Subscriber) AddSubscription(category ...string) error {
+	return nil
+}
+func (s *Subscriber) RemoveSubscription(category ...string) error {
+	return nil
+}
+
+/*
+//Subscribe will subscribe a subscriber to the news service
+func (ns *NewsService) Subscribe(ctx context.Context) {
+
+}
+
+//UnSubscribe will unsubscribe a subscriber from the news service
+func (ns *NewsService) Unsubscribe(ctx context.Context) {
+
+}
+*/

--- a/week09/pkg/newsmill/subscriber_test.go
+++ b/week09/pkg/newsmill/subscriber_test.go
@@ -1,0 +1,26 @@
+package newsmill
+
+/*
+import (
+	"fmt"
+	"testing"
+)
+
+func TestSubscribe(t *testing.T) {
+
+	cat := Category("people")
+	cat2 := Category("sport")
+
+	mysub := Subscriber{
+		ID:    2,
+		email: "sasa@sasa.com",
+	}
+
+	mysub.Subscribe(2, cat, cat2)
+
+	fmt.Println(mysub)
+
+	mysub.UnSubscribe(2, cat2)
+	fmt.Println(mysub)
+
+}*/


### PR DESCRIPTION
# Newsmill app initial set up
This PR defines the folder structure of the Newsmill app and the types to be used across the app.

The folder structure is as follows:
/cmd - the code for the command line calls will be in this folder
/pkg/newsmill - my importable package _newsmill_ 
/testdata - all json files + news source mock will be found in this folder


## Changes Summary
Added:
service.go - defines news service types and the required methods/functions
source.go - defines sources types and the required sources methods/functions
subscriber.go - defines subscribers types and the required subscriber methods/functions
errors.go - defines errors types and the required errors methods/functions across the app

## Difficulties
Still debating the best approach, either to use buffered channels or unbuffered.

## Surprises
After I put some meat into my code, I will be getting some surprises but at this time..no surprises :)